### PR TITLE
fix(DP-374): Update negative wordings

### DIFF
--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -31,7 +31,7 @@ const queryToText = (node: RuleGroupType) => {
           return "were not recorded as having race ";
         case "Gender":
           return `were not recorded as having ${mapDomain(
-            "gender"
+            "gender",
           ).toLowerCase()}`;
         default:
           return "not associated with";
@@ -77,7 +77,7 @@ const queryToText = (node: RuleGroupType) => {
 
   const leafText = (
     rule: ConceptOperator,
-    exclude: boolean
+    exclude: boolean,
   ): { verb: string | null; text: string | null } => {
     const c = rule.concept;
     if (!c) return { verb: null, text: null };


### PR DESCRIPTION
<img width="1228" height="841" alt="Screenshot 2026-01-22 at 15 05 55" src="https://github.com/user-attachments/assets/f4bd8f59-4561-47f7-b9b3-8d0c31d83405" />

Now makes much better sense, including in groups and with and/or