### PR TITLE
fix(DP-423): Fix Download button in Query Results page

### DIFF
--- a/src/components/DownloadButton/DownloadButton.tsx
+++ b/src/components/DownloadButton/DownloadButton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { IconButtonProps } from "@mui/material";
 
 import DownloadIcon from "@mui/icons-material/Download";
@@ -11,8 +9,10 @@ export enum AvailableFormats {
   CSV = "csv",
 }
 
-export interface DownloadButtonProps
-  extends Omit<IconButtonProps<"a">, "ref" | "href" | "component"> {
+export interface DownloadButtonProps extends Omit<
+  IconButtonProps<"a">,
+  "ref" | "href" | "component"
+> {
   id?: string;
   entity?: string;
   formats?: AvailableFormats[];


### PR DESCRIPTION
Don't force DownloadButton to client, so we can access AvailableFormats on the server when needed