### PR TITLE
fix(DP-530): Force textboxes to stay correct size

### DIFF
--- a/src/components/RuleAgeSelector/RuleAgeSelector.tsx
+++ b/src/components/RuleAgeSelector/RuleAgeSelector.tsx
@@ -307,9 +307,16 @@ const RuleAgeSelector = ({
                   max: maxAge,
                   type: "number",
                   "aria-labelledby": "input-slider",
+                  sx: { p: 0.5 },
                 },
               }}
-              sx={{ width: "20ch" }}
+              sx={{
+                maxWidth: "7ch",
+                flexShrink: 0,
+                "& .MuiOutlinedInput-root": {
+                  borderRadius: 1,
+                },
+              }}
             />
             <Slider
               value={sliderValue}
@@ -345,9 +352,16 @@ const RuleAgeSelector = ({
                   max: maxAge,
                   type: "number",
                   "aria-labelledby": "input-slider",
+                  sx: { p: 0.5 },
                 },
               }}
-              sx={{ width: "20ch" }}
+              sx={{
+                maxWidth: "7ch",
+                flexShrink: 0,
+                "& .MuiOutlinedInput-root": {
+                  borderRadius: 1,
+                },
+              }}
             />
           </>
         )}


### PR DESCRIPTION
## Summary

Make textboxes for age slider always be wide enough. It's not _perfect_ because the slider sometimes gets a bit unusably small, but full responsive behaviour to drop the text fields below the slider will need to wait.

## Jira

https://hdruk.atlassian.net/browse/DP-530

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence


https://github.com/user-attachments/assets/7497b7ee-5453-4ce7-bb90-06090d36ca5b


## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
