### PR TITLE
fix(DP-534): [UX][FE] Age refinement operators should toggle by default

### DIFF
--- a/src/components/DoubleBoundSelector/DoubleBoundSelector.tsx
+++ b/src/components/DoubleBoundSelector/DoubleBoundSelector.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Stack } from "@mui/material";
+import { DatePicker, DatePickerProps } from "@mui/x-date-pickers/DatePicker";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { useMemo } from "react";
+import dayjs, { Dayjs } from "dayjs";
+import useQueryBuilder from "@/hooks/useQueryBuilder";
+import { RuleLeafType } from "@/types/rules";
+import { PickerValue } from "@mui/x-date-pickers/internals";
+import { updateById } from "@/utils/rules";
+
+export default function DoubleBoundSelector({
+  rule,
+  commonPickerProps,
+  guidanceKey,
+}: {
+  rule: RuleLeafType;
+  commonPickerProps: DatePickerProps;
+  guidanceKey: string;
+}) {
+  const { queryBuilderJson, setQueryBuilderJson, setSelectedGuidance } =
+    useQueryBuilder((qb) => ({
+      queryBuilderJson: qb.queryBuilderJson,
+      setQueryBuilderJson: qb.setQueryBuilderJson,
+      setSelectedGuidance: qb.setSelectedGuidance,
+    }));
+
+  const [leftValue, rightValue] = useMemo<[Dayjs | null, Dayjs | null]>(() => {
+    const [start, end] = rule.timeConstraint ?? [null, null];
+    return [start ? dayjs(start) : null, end ? dayjs(end) : null];
+  }, [rule.timeConstraint]);
+
+  const handleLeftChange = (value: PickerValue) => {
+    setSelectedGuidance(guidanceKey, true);
+    setQueryBuilderJson(
+      updateById(queryBuilderJson, rule.id, (node) => ({
+        ...node,
+        timeConstraint: [
+          value?.toISOString() ?? null,
+          rightValue?.toISOString() ?? null,
+        ],
+      })),
+    );
+  };
+
+  const handleRightChange = (value: PickerValue) => {
+    setSelectedGuidance(guidanceKey, true);
+    setQueryBuilderJson(
+      updateById(queryBuilderJson, rule.id, (node) => ({
+        ...node,
+        timeConstraint: [
+          leftValue?.toISOString() ?? null,
+          value?.toISOString() ?? null,
+        ],
+      })),
+    );
+  };
+
+  return (
+    <Stack direction="row" spacing={2} alignItems="center">
+      <DatePicker
+        {...commonPickerProps}
+        value={leftValue}
+        onChange={handleLeftChange}
+      />
+      <ArrowForwardIcon />
+      <DatePicker
+        {...commonPickerProps}
+        value={rightValue}
+        onChange={handleRightChange}
+      />
+    </Stack>
+  );
+}

--- a/src/components/DoubleBoundSelector/index.ts
+++ b/src/components/DoubleBoundSelector/index.ts
@@ -1,0 +1,3 @@
+import DoubleBoundSelector from "./DoubleBoundSelector";
+
+export default DoubleBoundSelector;

--- a/src/components/RuleAgeSelector/RuleAgeSelector.tsx
+++ b/src/components/RuleAgeSelector/RuleAgeSelector.tsx
@@ -9,7 +9,11 @@ import {
 } from "@mui/material";
 import { ReactNode, useMemo, useState } from "react";
 import { isAgeFilter, isRuleLeaf, updateById } from "@/utils/rules";
-import { AgeFilterType, RuleLeafType } from "@/types/rules";
+import {
+  AgeFilterType,
+  RuleLeafType,
+  SingleSidedOperator,
+} from "@/types/rules";
 import { CustomH1 } from "@/components/GuidanceHeaders";
 import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
 import useFeatures from "@/hooks/useFeatures";
@@ -194,9 +198,12 @@ const RuleAgeSelector = ({
 
         <SingleBoundSelector<number>
           constraint={ageConstraint}
+          constraintOperator={
+            rule.ageConstraintOperator ?? SingleSidedOperator.GREATER_THAN
+          }
           readOnly={readOnly}
           anyLabel="Any age"
-          onConstraintChange={(next) => {
+          onConstraintChange={(next, nextOperator) => {
             setSelectedGuidance(key, true);
 
             setQueryBuilderJson(
@@ -213,6 +220,7 @@ const RuleAgeSelector = ({
                       left != null && left > minAge ? left : null,
                       right != null && right < maxAge ? right : null,
                     ],
+                    ageConstraintOperator: nextOperator,
                   };
                 }
 

--- a/src/components/RuleTimeframeSelector/RuleTimeframeSelector.tsx
+++ b/src/components/RuleTimeframeSelector/RuleTimeframeSelector.tsx
@@ -1,26 +1,22 @@
 "use client";
 
-import { Stack } from "@mui/material";
-import { ReactNode, useCallback, useMemo } from "react";
+import { ReactNode, useCallback } from "react";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { updateById } from "@/utils/rules";
-import { RuleLeafType } from "@/types/rules";
+import { RuleLeafType, SingleSidedOperator } from "@/types/rules";
 import dayjs, { Dayjs } from "dayjs";
 import {
   DatePicker,
   DatePickerProps,
   DatePickerSlotProps,
 } from "@mui/x-date-pickers/DatePicker";
-import { PickerValue } from "@mui/x-date-pickers/internals";
 import { CustomH1 } from "@/components/GuidanceHeaders";
-import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import useFeatures from "@/hooks/useFeatures";
 import { getDomainVerbs } from "@/utils/omop";
 import { capitaliseFirstLetter } from "@/utils/string";
 
-import SingleBoundSelector, {
-  SingleSidedOperator,
-} from "@/components/SingleBoundSelector";
+import SingleBoundSelector from "@/components/SingleBoundSelector";
+import DoubleBoundSelector from "@/components/DoubleBoundSelector";
 import { collapsibleGuidanceKey } from "@/utils/queryBuilder";
 
 export interface RuleTimeframeSelectorProps extends DatePickerProps {
@@ -54,38 +50,7 @@ const RuleTimeframeSelector = ({
 
   const { constrainForBunnyV1 } = useFeatures();
 
-  const [leftValue, rightValue] = useMemo<[Dayjs | null, Dayjs | null]>(() => {
-    const [start, end] = rule.timeConstraint ?? [null, null];
-    return [start ? dayjs(start) : null, end ? dayjs(end) : null];
-  }, [rule.timeConstraint]);
-
   const key = collapsibleGuidanceKey("RuleTimeframeSelector", selected);
-
-  const handleLeftChange = (value: PickerValue) => {
-    setSelectedGuidance(key, true);
-    setQueryBuilderJson(
-      updateById(queryBuilderJson, rule.id, (node) => ({
-        ...node,
-        timeConstraint: [
-          value?.toISOString() ?? null,
-          rightValue?.toISOString() ?? null,
-        ],
-      })),
-    );
-  };
-
-  const handleRightChange = (value: PickerValue) => {
-    setSelectedGuidance(key, true);
-    setQueryBuilderJson(
-      updateById(queryBuilderJson, rule.id, (node) => ({
-        ...node,
-        timeConstraint: [
-          leftValue?.toISOString() ?? null,
-          value?.toISOString() ?? null,
-        ],
-      })),
-    );
-  };
 
   const mergedSlotProps: DatePickerSlotProps<false> = {
     ...slotProps,
@@ -134,12 +99,16 @@ const RuleTimeframeSelector = ({
 
         <SingleBoundSelector<string, Dayjs>
           constraint={rule.timeConstraint}
-          onConstraintChange={(next) => {
+          constraintOperator={
+            rule.timeConstraintOperator ?? SingleSidedOperator.GREATER_THAN
+          }
+          onConstraintChange={(next, nextOperator) => {
             setSelectedGuidance(key, true);
             setQueryBuilderJson(
               updateById(queryBuilderJson, rule.id, (node) => ({
                 ...node,
                 timeConstraint: next,
+                timeConstraintOperator: nextOperator,
               })),
             );
           }}
@@ -172,19 +141,11 @@ const RuleTimeframeSelector = ({
   return (
     <>
       {title && <CustomH1>{title}</CustomH1>}
-      <Stack direction="row" spacing={2} alignItems="center">
-        <DatePicker
-          {...commonPickerProps}
-          value={leftValue}
-          onChange={handleLeftChange}
-        />
-        <ArrowForwardIcon />
-        <DatePicker
-          {...commonPickerProps}
-          value={rightValue}
-          onChange={handleRightChange}
-        />
-      </Stack>
+      <DoubleBoundSelector
+        rule={rule}
+        commonPickerProps={commonPickerProps}
+        guidanceKey={key}
+      />
       {children}
     </>
   );

--- a/src/components/SingleBoundSelector/OperatorToggle.tsx
+++ b/src/components/SingleBoundSelector/OperatorToggle.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ClickAwayListener, Collapse, Stack, Tooltip } from "@mui/material";
-import { SingleSidedOperator } from "./SingleBoundSelector";
+import { SingleSidedOperator } from "@/types/rules";
 import CircularIconButton from "../CircularIconButton";
 
 interface OperatorToggleProps {

--- a/src/components/SingleBoundSelector/SingleBoundSelector.tsx
+++ b/src/components/SingleBoundSelector/SingleBoundSelector.tsx
@@ -2,12 +2,9 @@
 
 import { Paper, Stack } from "@mui/material";
 import { ReactNode, useMemo } from "react";
-import OperatorToggle from "./OpperatorToggle";
+import { SingleSidedOperator } from "@/types/rules";
 
-export enum SingleSidedOperator {
-  GREATER_THAN = "gt",
-  LESS_THAN = "lt",
-}
+import OperatorToggle from "./OperatorToggle";
 
 export type NullablePair<T> = [T | null, T | null];
 
@@ -22,7 +19,12 @@ export type SingleBoundSelectorProps<TStored, TUi = TStored> = {
 
   constraint: NullablePair<TStored>;
 
-  onConstraintChange: (next: NullablePair<TStored>) => void;
+  constraintOperator: SingleSidedOperator;
+
+  onConstraintChange: (
+    next: NullablePair<TStored>,
+    nextOperator: SingleSidedOperator,
+  ) => void;
 
   parse?: (stored: TStored | null) => TUi | null;
 
@@ -48,6 +50,7 @@ export type SingleBoundSelectorProps<TStored, TUi = TStored> = {
 function deriveOperatorAndValue<TStored, TUi>(
   constraint: NullablePair<TStored>,
   parse: (stored: TStored | null) => TUi | null,
+  constraintOperator: SingleSidedOperator,
 ): { operator: SingleSidedOperator; value: TUi | null } {
   const [left, right] = constraint;
 
@@ -61,13 +64,14 @@ function deriveOperatorAndValue<TStored, TUi>(
   if (right != null)
     return { operator: SingleSidedOperator.LESS_THAN, value: parse(right) };
 
-  return { operator: SingleSidedOperator.GREATER_THAN, value: null };
+  return { operator: constraintOperator, value: null };
 }
 
 export default function SingleBoundSelector<TStored, TUi = TStored>({
   title,
   children,
   constraint,
+  constraintOperator,
   onConstraintChange,
   parse,
   serialise,
@@ -89,8 +93,8 @@ export default function SingleBoundSelector<TStored, TUi = TStored>({
   );
 
   const { operator, value } = useMemo(
-    () => deriveOperatorAndValue(constraint, parseFn),
-    [parseFn, constraint],
+    () => deriveOperatorAndValue(constraint, parseFn, constraintOperator),
+    [parseFn, constraint, constraintOperator],
   );
 
   const handleOperatorChange = (
@@ -104,6 +108,7 @@ export default function SingleBoundSelector<TStored, TUi = TStored>({
       nextOperator === SingleSidedOperator.GREATER_THAN
         ? [stored, null]
         : [null, stored],
+      nextOperator,
     );
   };
 
@@ -113,6 +118,7 @@ export default function SingleBoundSelector<TStored, TUi = TStored>({
       operator === SingleSidedOperator.GREATER_THAN
         ? [stored, null]
         : [null, stored],
+      operator,
     );
   };
 

--- a/src/components/SingleBoundSelector/index.ts
+++ b/src/components/SingleBoundSelector/index.ts
@@ -1,6 +1,5 @@
 import SingleBoundSelector from "./SingleBoundSelector";
-import { SingleSidedOperator, NullablePair } from "./SingleBoundSelector";
+import { NullablePair } from "./SingleBoundSelector";
 
-export { SingleSidedOperator };
 export type { NullablePair };
 export default SingleBoundSelector;

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -7,6 +7,11 @@ export enum CombinatorType {
   FOLLOWED_BY = "followed_by",
 }
 
+export enum SingleSidedOperator {
+  GREATER_THAN = "gt",
+  LESS_THAN = "lt",
+}
+
 export type ConceptOperator = {
   //ageConstraint: string;
   //valueConstraint: string;
@@ -21,7 +26,9 @@ type Node = {
   warnings?: string[];
   name?: string;
   timeConstraint?: [string | null, string | null];
+  timeConstraintOperator?: SingleSidedOperator;
   ageConstraint?: [number | null, number | null];
+  ageConstraintOperator?: SingleSidedOperator;
 };
 
 export interface OperatorType extends Node {
@@ -36,8 +43,10 @@ export interface RuleLeafType extends Node {
   rule: ConceptOperator;
 }
 
-export interface AgeFilterType
-  extends Omit<Node, "exclude" | "timeConstraint" | "ageConstraint"> {
+export interface AgeFilterType extends Omit<
+  Node,
+  "exclude" | "timeConstraint" | "ageConstraint"
+> {
   value: [number, number];
 }
 


### PR DESCRIPTION
## Summary

Allow changing of operator when a date or age has not been selected.

Fixes handling of operators in SingleBoundSelector by managing the state of the operator separately from the constraints. Also split out DoubleBoundSelector as a new component for ease

## Jira

https://hdruk.atlassian.net/browse/DP-534

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence


https://github.com/user-attachments/assets/a0093012-d6ea-46b0-90f5-e3fcdc987f3f



## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
