### PR TITLE
feat(DP-558): Don't allow group nesting

### DIFF
--- a/src/components/HierarchyItem/HierarchyItem.style.ts
+++ b/src/components/HierarchyItem/HierarchyItem.style.ts
@@ -13,6 +13,7 @@ export const listItemButtonSx =
     depth: number,
     isSelected: boolean,
     isHovered: boolean,
+    isNotAllowed: boolean = false,
   ): SxProps<Theme> =>
   (theme) => ({
     color: theme.palette.text.primary,
@@ -40,7 +41,9 @@ export const listItemButtonSx =
         height: 3,
         top: isAbove ? 0 : "auto",
         bottom: isAbove ? "auto" : 0,
-        backgroundColor: theme.palette.primary.main,
+        backgroundColor: isNotAllowed
+          ? theme.palette.error.main
+          : theme.palette.primary.main,
         pointerEvents: "none",
       },
     }),

--- a/src/components/HierarchyItem/HierarchyItem.tsx
+++ b/src/components/HierarchyItem/HierarchyItem.tsx
@@ -22,12 +22,14 @@ type HierarchyItemProps = {
   node: RuleNodeType;
   groupId: string;
   depth?: number;
+  selectedIsGroup?: boolean;
 };
 
 export const HierarchyItem = ({
   node,
   groupId,
   depth = 0,
+  selectedIsGroup = false,
 }: HierarchyItemProps) => {
   const {
     select,
@@ -110,6 +112,7 @@ export const HierarchyItem = ({
         depth,
         selected[node.id],
         isHighlighted,
+        isOver && (isGroup || depth > 0) && selectedIsGroup,
       )}
     >
       <SquareRadio
@@ -178,6 +181,7 @@ export const HierarchyItem = ({
                     node={child}
                     groupId={node.id}
                     depth={depth + INDENT_STEP}
+                    selectedIsGroup={selectedIsGroup}
                   />
                 ))}
             </SortableContext>

--- a/src/modules/Hierarchy/Hierarchy.tsx
+++ b/src/modules/Hierarchy/Hierarchy.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { RuleNodeType } from "@/types/rules";
-import { moveItemIntoGroup } from "@/utils/rules";
+import { findById, isRuleGroup, moveItemIntoGroup } from "@/utils/rules";
 import {
   Active,
   DndContext,
@@ -37,20 +37,39 @@ export const Hierarchy = () => {
   const { rules } = queryBuilderJson;
 
   const [active, setActive] = useState<Active | null>(null);
+  const [activeNode, setActiveNode] = useState<RuleNodeType | null>(null);
   const hasMounted = useHasMounted();
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
 
-  const onDragStart = ({ active }: DragStartEvent) => setActive(active);
+  const onDragStart = useCallback(
+    (e: DragStartEvent) => {
+      setActive(e.active);
+
+      const node = findById(
+        queryBuilderJson,
+        e.active.data.current?.id as string,
+      );
+
+      if (node) {
+        setActiveNode(node);
+      }
+    },
+    [queryBuilderJson],
+  );
 
   const onDragEnd = useCallback(
     ({ over }: DragEndEvent) => {
       if (!active) return;
+      if (!activeNode) return;
       if (!over) return;
 
       const overGroupId = over?.data?.current?.groupId as string;
+      const activeGroupId = active?.data?.current?.groupId as string;
+
+      if (isRuleGroup(activeNode) && overGroupId !== activeGroupId) return;
 
       const activeId = active?.data?.current?.id;
       const overId = over?.data?.current?.id;
@@ -66,8 +85,9 @@ export const Hierarchy = () => {
       );
 
       setActive(null);
+      setActiveNode(null);
     },
-    [active, boardIndex, queryBuilderJson, setQueryBuilderJson],
+    [active, activeNode, boardIndex, queryBuilderJson, setQueryBuilderJson],
   );
 
   if (!hasMounted) return <SkeletonFull sx={{ minHeight: 1000, mt: 1 }} />;
@@ -79,7 +99,10 @@ export const Hierarchy = () => {
       measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
-      onDragCancel={() => setActive(null)}
+      onDragCancel={() => {
+        setActive(null);
+        setActiveNode(null);
+      }}
     >
       <List disablePadding>
         <SortableContext
@@ -92,6 +115,7 @@ export const Hierarchy = () => {
               key={node.id}
               node={node}
               groupId={queryBuilderJson.id}
+              selectedIsGroup={(activeNode && isRuleGroup(activeNode)) ?? false}
             />
           ))}
         </SortableContext>

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -120,7 +120,12 @@ export const CohortBuilderProvider = ({
       const activeGroupId = activeData?.groupId;
       const overGroupId = overData?.groupId;
 
-      if (!overGroupId || !activeGroupId) return;
+      if (
+        !overGroupId ||
+        !activeGroupId ||
+        (activeData.type === "Group" && overGroupId !== activeGroupId)
+      )
+        return;
       if (activeData.id === overData.id) return;
 
       const groupItems = boardIndex?.itemsByGroup?.[overGroupId] ?? [];
@@ -167,7 +172,11 @@ export const CohortBuilderProvider = ({
       const activeGroupId = activeData?.groupId;
       const overGroupId = overData?.groupId;
 
-      if (!overGroupId || !activeGroupId) {
+      if (
+        !overGroupId ||
+        !activeGroupId ||
+        (activeData.type === "Group" && overGroupId !== activeGroupId)
+      ) {
         setActiveNode(null);
         setActive(null);
         return;


### PR DESCRIPTION
## Summary

Stop groups from being dropped into one another, both in rule builder and in hierarchy.

## Jira

https://hdruk.atlassian.net/browse/DP-558

## PR Type

- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence


https://github.com/user-attachments/assets/c8261db9-e74a-4835-836b-30ab657edbe6


## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
