### PR TITLE
feat(DP-631): Users can open existing results in a new tab

### DIFF
--- a/src/modules/QueriesTable/QueriesTable.tsx
+++ b/src/modules/QueriesTable/QueriesTable.tsx
@@ -10,6 +10,7 @@ import {
   type MRT_ColumnDef,
 } from "material-react-table";
 import { Grid, Paper, Typography } from "@mui/material";
+import LaunchIcon from "@mui/icons-material/Launch";
 import dayjs from "dayjs";
 import { usePaginatedTable } from "@/hooks/usePaginatedTable";
 import { formatNumber } from "@/utils/numbers";
@@ -147,6 +148,14 @@ const QueriesTable = ({
   const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
   const [expanded, setExpanded] = useState<MRT_ExpandedState>({});
 
+  function openQueryResult(queryId: string): string {
+    const openQueries = (searchParams.get("open_queries") || "")
+      .split(/,|%2C/)
+      .concat(queryId)
+      .filter((q) => q !== "");
+    return routes.dashboardQueryResult(queryId, openQueries);
+  }
+
   const table = usePaginatedTable<Query>({
     columns,
     data: queries.data,
@@ -191,6 +200,11 @@ const QueriesTable = ({
           tableProps={{
             leftAction: {
               titleProps: {
+                startIcon: (
+                  <Link href={openQueryResult(row.original.pid)}>
+                    <LaunchIcon sx={{ ml: 0.25, verticalAlign: "middle" }} />
+                  </Link>
+                ),
                 title: `Query ${getQueryName(row.original)}`,
                 subTitle: "Results",
               },


### PR DESCRIPTION
## Summary

Add launch icon to query history subtables, so that user can open a tab for an existing result

## Jira

https://hdruk.atlassian.net/browse/DP-631

## PR Type

- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

https://github.com/user-attachments/assets/99c650b6-06a3-4444-9d0b-937860f8db1d



## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
