### PR TITLE
feat(DP-648): Add confirmation dialog to collection deletions

### DIFF
--- a/src/components/CollectionsTable/CollectionsTable.tsx
+++ b/src/components/CollectionsTable/CollectionsTable.tsx
@@ -18,6 +18,7 @@ import { useLogDependencyChanges } from "@/utils/deps";
 import useAdminStore from "@/hooks/useAdminStore";
 import useCustodianStore from "@/hooks/useCustodianStore";
 import useUserStore from "@/hooks/useUserStore";
+import { useConfirm } from "@/hooks/useConfirm";
 import { useNotify } from "@/providers/NotifyProvider";
 import {
   getTagCustodianCollection,
@@ -212,6 +213,20 @@ const CollectionsTable = ({
     }),
   });
 
+  const handleDeleteClick = async () => {
+    const ok = await confirm({
+      props: {
+        action: `delete the collection${selectedCollections.length > 1 ? "s" : ""} ${selectedCollections.map((c) => c.name).join(", ")}`,
+      },
+      confirmText: "Delete",
+      confirmColor: "error",
+    });
+    if (!ok || ok === "cancel") {
+      return;
+    }
+    handleDeleteCollections(selectedCollections.map((c) => c.id.toString()));
+  };
+
   const handleDeleteCollections = useCallback(
     async (ids: string[]) => {
       if (deleteOverride) {
@@ -254,6 +269,8 @@ const CollectionsTable = ({
     deleteCollectionAdmin,
   });
 
+  const confirm = useConfirm();
+
   return (
     <Table
       key="custodian-collection-table"
@@ -266,7 +283,9 @@ const CollectionsTable = ({
         },
       }}
       rightAction={{
-        deleteProps: { onClick: handleDeleteCollections },
+        deleteProps: {
+          onClick: handleDeleteClick,
+        },
         refreshProps: {
           tag:
             currentCustodian?.pid && !isAdmin

--- a/src/modules/UpdateNetwork/UpdateNetwork.tsx
+++ b/src/modules/UpdateNetwork/UpdateNetwork.tsx
@@ -36,7 +36,7 @@ const UpdateNetwork = () => {
     handleSubmit,
     control,
     reset,
-    formState: { defaultValues },
+    formState: { defaultValues, isDirty },
   } = formMethods;
 
   useEffect(() => {
@@ -60,22 +60,31 @@ const UpdateNetwork = () => {
   const submitForm = useCallback(
     async (data: UpdateNetworkFormValues, closeAfter = true) => {
       if (!selectedNetwork) return;
-      await updateNetwork(selectedNetwork.id, {
-        name: data.name,
-        url: data.url,
-      });
-
-      if (data.custodians.length > 0) {
-        await addCustodiansToNetwork({
-          custodian_ids: data.custodians.map((c) => +c.value),
-          id: selectedNetwork.id,
+      if (isDirty) {
+        await updateNetwork(selectedNetwork.id, {
+          name: data.name,
+          url: data.url,
         });
-      }
 
-      notify.success(`Updated network ${data.name}`);
+        if (data.custodians.length > 0) {
+          await addCustodiansToNetwork({
+            custodian_ids: data.custodians.map((c) => +c.value),
+            id: selectedNetwork.id,
+          });
+        }
+
+        notify.success(`Updated network ${data.name}`);
+      }
       if (closeAfter) onClose?.();
     },
-    [notify, onClose, addCustodiansToNetwork, updateNetwork, selectedNetwork],
+    [
+      isDirty,
+      notify,
+      onClose,
+      addCustodiansToNetwork,
+      updateNetwork,
+      selectedNetwork,
+    ],
   );
 
   const onSave = useCallback(


### PR DESCRIPTION
## Summary

Add confirmation dialog when deleting collections from table.
Also fix network update dirty so that it only updates when changed.

## Jira

https://hdruk.atlassian.net/browse/DP-648

## PR Type

- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

Confirm dialog for collections deletion, supporting single or multiple collections:

https://github.com/user-attachments/assets/e677520d-a171-44fb-b1e5-74b64a88bf8c

Network update panel only updates when form is dirty:

https://github.com/user-attachments/assets/8db10eb0-448b-4ba6-b862-a741ecd02eaa


## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
