### PR TITLE
fix(DP-707): Fix for collections selection bug

### DIFF
--- a/src/app/(protected)/components/ProtectedPage.tsx
+++ b/src/app/(protected)/components/ProtectedPage.tsx
@@ -42,7 +42,7 @@ const ProtectedPage = ({
     (qb) => qb.checkSelectedDatasets,
   );
 
-  const renderCount = useRef<number>(null);
+  const hasRendered = useRef(false);
 
   useEffect(() => {
     setUser(user);
@@ -65,10 +65,10 @@ const ProtectedPage = ({
   }, [featureFlags, setFlags]);
 
   useEffect(() => {
-    if (renderCount.current == null) {
+    if (!hasRendered.current) {
       initialiseSelectedDatasets(collections, isOnlyInDefaultWorkgroup);
     }
-    renderCount.current = 1;
+    hasRendered.current = true;
   }, [collections, initialiseSelectedDatasets, isOnlyInDefaultWorkgroup]);
 
   useEffect(() => {

--- a/src/app/(protected)/components/ProtectedPage.tsx
+++ b/src/app/(protected)/components/ProtectedPage.tsx
@@ -3,7 +3,7 @@
 import { Collection, CombinedUser, Custodian, Workgroup } from "@/types/api";
 import { FeatureFlag } from "@/types/features";
 import { redirect } from "next/navigation";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import { useFeatureFlagsStore } from "@/store/featureFlagsStore";
 import useUserStore from "@/hooks/useUserStore";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
@@ -38,6 +38,11 @@ const ProtectedPage = ({
   const initialiseSelectedDatasets = useQueryBuilder(
     (qb) => qb.initialiseSelectedDatasets,
   );
+  const checkSelectedDatasets = useQueryBuilder(
+    (qb) => qb.checkSelectedDatasets,
+  );
+
+  const renderCount = useRef<number>(null);
 
   useEffect(() => {
     setUser(user);
@@ -60,14 +65,16 @@ const ProtectedPage = ({
   }, [featureFlags, setFlags]);
 
   useEffect(() => {
+    if (renderCount.current == null) {
+      initialiseSelectedDatasets(collections, isOnlyInDefaultWorkgroup);
+    }
+    renderCount.current = 1;
+  }, [collections, initialiseSelectedDatasets, isOnlyInDefaultWorkgroup]);
+
+  useEffect(() => {
     if (!currentUser) return;
-    initialiseSelectedDatasets(collections, isOnlyInDefaultWorkgroup);
-  }, [
-    currentUser,
-    collections,
-    isOnlyInDefaultWorkgroup,
-    initialiseSelectedDatasets,
-  ]);
+    checkSelectedDatasets(collections);
+  }, [collections, currentUser, checkSelectedDatasets]);
 
   if (!user) redirect("/403?reason=no-token");
 

--- a/src/components/SubmitQueryButton/SubmitQueryButton.tsx
+++ b/src/components/SubmitQueryButton/SubmitQueryButton.tsx
@@ -39,10 +39,10 @@ const SubmitQueryButton = ({ warning = false }: { warning: boolean }) => {
           backgroundColor: theme.palette.grey[200],
         },
       })}
-      onClick={(event) => {
+      onClick={async (event) => {
         event.stopPropagation();
         event.preventDefault();
-        submit();
+        await submit();
         resetQueryBuilderJson(true);
       }}
     >

--- a/src/store/queryBuilderStore.ts
+++ b/src/store/queryBuilderStore.ts
@@ -130,6 +130,8 @@ export interface QueryBuilderStoreState {
     includeSynthetic: boolean,
   ) => void;
 
+  checkSelectedDatasets: (collections: Collection[]) => void;
+
   openSelectDatasetsPanel: boolean;
   setOpenSelectDatasetsPanel: (value: boolean) => void;
 
@@ -404,6 +406,18 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
   initialiseSelectedDatasets: (collections, includeSynthetic) => {
     const { selectedDatasets } = get();
     const allowedIds = getAllowedDatasetIds(collections, includeSynthetic);
+
+    const nextSelectedDatasets =
+      selectedDatasets.length === 0
+        ? allowedIds
+        : intersection(allowedIds, selectedDatasets);
+
+    get().setSelectedDatasets(nextSelectedDatasets);
+  },
+
+  checkSelectedDatasets: (collections) => {
+    const { selectedDatasets } = get();
+    const allowedIds = getAllowedDatasetIds(collections, true);
 
     const nextSelectedDatasets =
       selectedDatasets.length === 0


### PR DESCRIPTION
## Summary

We now only apply the "default workgroup only -> select synthetics" fudge on first re-render. On all renders we still check for changes to collections to remove any they shouldn't have access to.

Note that, on a hard refresh, the fudge will be re-applied, but this seems a sensible upgrade from where we are currently until we can (if we decide to) handle continuity between sessions.

## Jira

https://hdruk.atlassian.net/browse/DP-707

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

https://github.com/user-attachments/assets/652bb181-63b5-4ef0-be5c-15af27f30f95

Selected collections are maintained when running.a query and returning to query builder, including synthetics.
On hard-refresh, it returns to the expected setting (which is to remove any previously selected synthetic datasets, because my user is in multiple workgroups)

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
