### PR TITLE
fix(DP-714): Correctly format workgroup names in middle panel

### DIFF
--- a/src/app/(protected)/(admin)/admin/[tabId]/components/WorkgroupsMiddlePanel.tsx
+++ b/src/app/(protected)/(admin)/admin/[tabId]/components/WorkgroupsMiddlePanel.tsx
@@ -2,7 +2,7 @@
 
 import CollectionsTable from "@/components/CollectionsTable";
 import { Box, Stack, Typography } from "@mui/material";
-import { capitaliseFirstLetter } from "@/utils/string";
+import { formatWorkgroupName } from "@/utils/workgroups";
 import useAdminStore from "@/hooks/useAdminStore";
 import { useNotify } from "@/providers/NotifyProvider";
 import UserTable from "@/components/UserTable";
@@ -35,9 +35,7 @@ const WorkgroupsMiddlePanel = () => {
         <Stack gap={2}>
           <Box>
             <CollectionsTable
-              tableTitle={`${capitaliseFirstLetter(
-                selectedWorkgroup?.name.toLowerCase(),
-              )} Workgroup`}
+              tableTitle={`${formatWorkgroupName(selectedWorkgroup?.name)} Workgroup`}
               tableSubTitle="Collections"
               deleteOverride={async (ids: string[]) => {
                 await removeCollectionsFromWorkgroup({
@@ -57,9 +55,7 @@ const WorkgroupsMiddlePanel = () => {
           {manageWorkgroupsInternal && (
             <Box>
               <UserTable
-                tableTitle={`${capitaliseFirstLetter(
-                  selectedWorkgroup?.name.toLowerCase(),
-                )} Workgroup`}
+                tableTitle={`${formatWorkgroupName(selectedWorkgroup?.name)} Workgroup`}
                 tableSubTitle="Users"
                 handleDelete={async (ids: string[]) => {
                   await removeUsersFromWorkgroup({


### PR DESCRIPTION
## Summary

Apply correct formatting

## Jira

https://hdruk.atlassian.net/browse/DP-714

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<img width="1384" height="1200" alt="image" src="https://github.com/user-attachments/assets/8b970898-baca-4005-a113-0b09d22006bb" />

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
