### PR TITLE
fix(DP-696): Collection, Network and Workgroup panels now select first option on load

### DIFF
--- a/src/app/(protected)/(admin)/admin/[tabId]/components/NetworksLeftPanel.tsx
+++ b/src/app/(protected)/(admin)/admin/[tabId]/components/NetworksLeftPanel.tsx
@@ -24,7 +24,7 @@ const NetworksLeftPanel = () => {
 
   useEffect(() => {
     const network = networks.find((w) => String(w.id) === workgroupId);
-    setSelectedNetwork(network ?? null);
+    setSelectedNetwork(network ?? (networks.length >= 1 ? networks[0] : null));
   }, [networks, workgroupId, setSelectedNetwork]);
 
   const onSelectNetwork = useCallback(

--- a/src/app/(protected)/(admin)/admin/[tabId]/components/WorkgroupsLeftPanel.tsx
+++ b/src/app/(protected)/(admin)/admin/[tabId]/components/WorkgroupsLeftPanel.tsx
@@ -25,7 +25,9 @@ const WorkgroupsLeftPanel = () => {
 
   useEffect(() => {
     const workgroup = workgroups.find((w) => String(w.id) === workgroupId);
-    setSelectedWorkgroup(workgroup ?? null);
+    setSelectedWorkgroup(
+      workgroup ?? (workgroups.length >= 1 ? workgroups[0] : null),
+    );
   }, [workgroups, workgroupId, setSelectedWorkgroup]);
 
   const onSelectWorkgroup = useCallback(

--- a/src/modules/CollectionsLeftPanel/CollectionsLeftPanel.tsx
+++ b/src/modules/CollectionsLeftPanel/CollectionsLeftPanel.tsx
@@ -65,7 +65,8 @@ const CollectionsLeftPanel = () => {
                 label: "All Collections",
                 onClick: () =>
                   onSelectCollectionsStatus(CollectionFilterStatus.ALL),
-                selected: searchParam === CollectionFilterStatus.ALL,
+                selected:
+                  searchParam === CollectionFilterStatus.ALL || !searchParam,
               },
               {
                 label: "Draft Collections",


### PR DESCRIPTION
## Summary

## Jira

https://hdruk.atlassian.net/browse/DP-696

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

When no Collections available:
<img width="1384" height="1126" alt="image" src="https://github.com/user-attachments/assets/666e698a-348f-47a2-bdc2-18c705078080" />

When collections available:
<img width="1384" height="1126" alt="image" src="https://github.com/user-attachments/assets/c3ae4ecd-baec-46b3-970f-b78c13ad957c" />

Same applies for networks and workgroups

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
