### PR TITLE
fix(DP-710): Allow single-click editing of query title

### DIFF
--- a/src/components/CohortQueryTitle/CohortQueryTitle.tsx
+++ b/src/components/CohortQueryTitle/CohortQueryTitle.tsx
@@ -17,6 +17,7 @@ const CohortQueryTitle = () => {
       title={"Query Name"}
       subTitle={
         <EditableText
+          singleClick
           defaultValue={queryName || ""}
           onCommit={(name) => {
             if (name.length >= 3) {

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -19,6 +19,7 @@ export type EditableTextProps = {
   trim?: boolean;
   placeholder?: string;
   showIcon?: boolean;
+  singleClick?: boolean;
 };
 
 type FormValues = {
@@ -35,6 +36,7 @@ const EditableText = ({
   trim = true,
   placeholder,
   showIcon = false,
+  singleClick = false,
 }: EditableTextProps) => {
   const [editing, setEditing] = useState(!defaultValue);
   const [hovering, setHovering] = useState(false);
@@ -83,6 +85,11 @@ const EditableText = ({
   };
 
   const handleClick = (e: React.MouseEvent<HTMLSpanElement>) => {
+    if (singleClick) {
+      startEditing(e);
+      return;
+    }
+
     if (clickTimeoutRef.current !== null) {
       window.clearTimeout(clickTimeoutRef.current);
       clickTimeoutRef.current = null;


### PR DESCRIPTION
## Summary

Add singleClick prop to EditableText. Use that on QueryTitle but not on HierarchyItem or RuleWrapper

## Jira

https://hdruk.atlassian.net/browse/DP-710

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence


https://github.com/user-attachments/assets/4c1c05b5-90bf-41ba-a20d-d4e91c1dcd6d


## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
