### PR TITLE
feat(DP-697): Add 'manage' section to 'Hosts' page

### DIFF
--- a/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostLeftPanel.tsx
+++ b/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostLeftPanel.tsx
@@ -4,6 +4,8 @@ import ActionMenuSection from "@/components/ActionMenuSection";
 import AddButton from "@/components/AddButton";
 import CreateCollectionHost from "@/modules/CreateCollectionHost";
 import { useThreePane } from "@/providers/ThreePaneProvider";
+import List from "@/components/List";
+import useSearchParams from "@/hooks/useSearchParams";
 
 type CollectionHostLeftPanelProps = {
   custodianId: number;
@@ -13,6 +15,11 @@ const CollectionHostLeftPanel = ({
   custodianId,
 }: CollectionHostLeftPanelProps) => {
   const { expandedLeft, toggleLeft } = useThreePane();
+
+  //does nothing yet
+  // - here for the future if a host filter is to be implemented
+  const { getSearchParam } = useSearchParams("collection_host_filter");
+  const searchParam = getSearchParam();
 
   return (
     <Box
@@ -51,6 +58,23 @@ const CollectionHostLeftPanel = ({
           />
         </ActionMenuSection>
       )}
+
+      <ActionMenuSection
+        hidden={expandedLeft}
+        title={"Manage"}
+        defaultExpanded
+        underline
+      >
+        <List
+          items={[
+            {
+              label: "All Hosts",
+              onClick: () => ({}),
+              selected: !searchParam,
+            },
+          ]}
+        />
+      </ActionMenuSection>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

* show a menu on the left hand side for hosts (even though it doesnt do anything yet)

<img width="784" height="560" alt="image" src="https://github.com/user-attachments/assets/4e2daac2-9759-4673-93c4-5167b6175b9a" />

## Jira

* https://hdruk.atlassian.net/browse/DP-697 

## PR Type

- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<!-- For UI work, add before/after screenshots or short video. -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
