### PR TITLE
fix(DP-778): Select Datasets is a fixed height

### DIFF
--- a/src/components/SelectDatasets/SelectDatasets.tsx
+++ b/src/components/SelectDatasets/SelectDatasets.tsx
@@ -135,9 +135,6 @@ const SelectDatasets = () => {
         ...(open && {
           mt: 2,
           mb: 2,
-          flex: 1,
-          minHeight: 0,
-          overflow: "auto",
         }),
       }}
     >
@@ -168,7 +165,14 @@ const SelectDatasets = () => {
           defaultExpanded
           disableGutters
           elevation={1}
-          sx={{ bgcolor: "white", mb: 1 }}
+          sx={{
+            bgcolor: "white",
+            mb: 1,
+            maxHeight: 500,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "auto",
+          }}
         >
           <AccordionSummary>
             <Title

--- a/src/hooks/useScrollToNode.ts
+++ b/src/hooks/useScrollToNode.ts
@@ -1,0 +1,48 @@
+import { RefObject, useEffect } from "react";
+import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
+import { getScrollParent } from "@/utils/html";
+
+type UseScrollToNodeArgs = {
+  enabled: boolean;
+  boardRef: RefObject<HTMLElement | null>;
+};
+
+const useScrollToNode = ({ enabled, boardRef }: UseScrollToNodeArgs) => {
+  const { getSortableNode, pendingScrollToNodeId, clearPendingScrollToNodeId } =
+    useCohortBuilderContext();
+
+  useEffect(() => {
+    if (!enabled || !pendingScrollToNodeId) return;
+
+    const board = boardRef.current;
+    const container = getScrollParent(board);
+    const el = getSortableNode(pendingScrollToNodeId);
+
+    if (!container || !el) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+
+    const top =
+      elRect.top -
+      containerRect.top +
+      container.scrollTop -
+      container.clientHeight / 2 +
+      elRect.height / 2;
+
+    container.scrollTo({
+      top,
+      behavior: "smooth",
+    });
+
+    clearPendingScrollToNodeId();
+  }, [
+    enabled,
+    boardRef,
+    getSortableNode,
+    pendingScrollToNodeId,
+    clearPendingScrollToNodeId,
+  ]);
+};
+
+export default useScrollToNode;

--- a/src/hooks/useSortable.ts
+++ b/src/hooks/useSortable.ts
@@ -9,6 +9,7 @@ import { useElementSize } from "./useElementSize";
 import { quantise } from "@/utils/numbers";
 import { useDndContext } from "@dnd-kit/core";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
+import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
 
 export interface UseSortablePlusReturn extends ReturnType<
   typeof useDndSortable
@@ -24,8 +25,17 @@ export interface UseSortablePlusReturn extends ReturnType<
 const useSortable = (args: UseSortableArguments): UseSortablePlusReturn => {
   const boardIndex = useQueryBuilder((s) => s.boardIndex);
 
-  const params = useDndSortable(args);
+  const { setNodeRef: setNodeRefDnd, ...params } = useDndSortable(args);
   const { over, active } = useDndContext();
+  const { registerSortableNode } = useCohortBuilderContext();
+
+  const setNodeRef = React.useCallback(
+    (node: HTMLElement | null) => {
+      setNodeRefDnd(node);
+      registerSortableNode(String(args.id), node);
+    },
+    [args.id, setNodeRefDnd, registerSortableNode],
+  );
 
   const isOver = useMemo(
     () => over?.id !== active?.id && over?.id === args.id,
@@ -79,6 +89,7 @@ const useSortable = (args: UseSortableArguments): UseSortablePlusReturn => {
 
   return {
     ...params,
+    setNodeRef,
     isLast,
     style,
     anchorRef,

--- a/src/modules/ActionMenu/ActionMenu.tsx
+++ b/src/modules/ActionMenu/ActionMenu.tsx
@@ -9,21 +9,11 @@ import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { Box } from "@mui/material";
 import SkeletonFull from "@/components/SkeletonFull";
 import useStateManagement from "@/hooks/useStateManagement";
+import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
 
 const ActionMenu: React.FC = () => {
-  const {
-    queryBuilderJson,
-    createNewGroup,
-    createNewRule,
-    createNewAgeFilter,
-    createNewOperator,
-  } = useQueryBuilder((qb) => ({
-    queryBuilderJson: qb.queryBuilderJson,
-    createNewGroup: qb.createNewGroup,
-    createNewRule: qb.createNewRule,
-    createNewAgeFilter: qb.createNewAgeFilter,
-    createNewOperator: qb.createNewOperator,
-  }));
+  const queryBuilderJson = useQueryBuilder((qb) => qb.queryBuilderJson);
+  const { actions } = useCohortBuilderContext();
 
   const isLoading = useStateManagement((s) => s.isLoading);
   if (isLoading) {
@@ -46,10 +36,9 @@ const ActionMenu: React.FC = () => {
         defaultExpanded
         underline
       >
-        <AddButton onClick={createNewRule} label={"Add rule"} />
-        <AddButton onClick={createNewOperator} label={"Add operator"} />
-        <AddButton onClick={createNewAgeFilter} label={"Add age rule"} />
-        <AddButton onClick={createNewGroup} label={"Add group"} />
+        {actions.map(({ action, label }) => (
+          <AddButton key={label} onClick={action} label={label} />
+        ))}
       </ActionMenuSection>
       <ActionMenuSection
         title={"Hierarchy"}

--- a/src/modules/QueryBuilder/QueryBuilder.tsx
+++ b/src/modules/QueryBuilder/QueryBuilder.tsx
@@ -59,7 +59,7 @@ const QueryBuilder = ({
           left={<ActionMenu />}
           middle={
             queryBuilderJson?.rules && queryBuilderJson.rules.length > 0 ? (
-              <RuleBoard ruleGroup={queryBuilderJson} />
+              <RuleBoard ruleGroup={queryBuilderJson} scrollable />
             ) : (
               <QueryBuilderSkeleton />
             )

--- a/src/modules/RuleBoard/RuleBoard.tsx
+++ b/src/modules/RuleBoard/RuleBoard.tsx
@@ -25,6 +25,7 @@ import SkeletonFull from "@/components/SkeletonFull";
 import useStateManagement from "@/hooks/useStateManagement";
 import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
 import { getScrollParent } from "@/utils/html";
+import useScrollToNode from "@/hooks/useScrollToNode";
 
 interface RuleBoardProps extends BoxProps {
   ruleGroup: RuleGroupType;
@@ -64,40 +65,10 @@ const RuleBoard = ({
   const isLoading = useStateManagement((s) => s.isLoading);
   const hasMounted = useHasMounted();
 
-  const { getSortableNode, pendingScrollToNodeId, clearPendingScrollToNodeId } =
-    useCohortBuilderContext();
-
-  useEffect(() => {
-    if (!scrollable || !pendingScrollToNodeId) return;
-
-    const board = boardRef.current;
-    const container = getScrollParent(board);
-    const el = getSortableNode(pendingScrollToNodeId);
-
-    if (!container || !el) return;
-
-    const containerRect = container.getBoundingClientRect();
-    const elRect = el.getBoundingClientRect();
-
-    const top =
-      elRect.top -
-      containerRect.top +
-      container.scrollTop -
-      container.clientHeight / 2 +
-      elRect.height / 2;
-
-    container.scrollTo({
-      top,
-      behavior: "smooth",
-    });
-
-    clearPendingScrollToNodeId();
-  }, [
-    scrollable,
-    getSortableNode,
-    pendingScrollToNodeId,
-    clearPendingScrollToNodeId,
-  ]);
+  useScrollToNode({
+    enabled: scrollable,
+    boardRef,
+  });
 
   if (!hasMounted || isLoading) {
     return <SkeletonFull />;

--- a/src/modules/RuleBoard/RuleBoard.tsx
+++ b/src/modules/RuleBoard/RuleBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment } from "react";
+import { Fragment, useEffect, useRef } from "react";
 
 import Rule from "@/modules/Rule";
 import {
@@ -23,9 +23,12 @@ import useHasMounted from "@/hooks/useHasMounted";
 import RuleAgeFilter from "../RuleAgeFilter";
 import SkeletonFull from "@/components/SkeletonFull";
 import useStateManagement from "@/hooks/useStateManagement";
+import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
+import { getScrollParent } from "@/utils/html";
 
 interface RuleBoardProps extends BoxProps {
   ruleGroup: RuleGroupType;
+  scrollable?: boolean;
 }
 
 function renderRule(item: RuleNodeType, ruleGroupId: string) {
@@ -40,15 +43,61 @@ function renderRule(item: RuleNodeType, ruleGroupId: string) {
   }
 }
 
-const RuleBoard = ({ ruleGroup, children, ...rest }: RuleBoardProps) => {
+const RuleBoard = ({
+  ruleGroup,
+  children,
+  scrollable = false,
+  ...rest
+}: RuleBoardProps) => {
   const { rules, id } = ruleGroup;
   const { setNodeRef } = useDroppable({
     id,
     data: { type: "container", containerId: id },
   });
+  const boardRef = useRef<HTMLDivElement | null>(null);
+
+  const setBoardRef = (el: HTMLDivElement | null) => {
+    setNodeRef(el);
+    boardRef.current = el;
+  };
 
   const isLoading = useStateManagement((s) => s.isLoading);
   const hasMounted = useHasMounted();
+
+  const { getSortableNode, pendingScrollToNodeId, clearPendingScrollToNodeId } =
+    useCohortBuilderContext();
+
+  useEffect(() => {
+    if (!scrollable || !pendingScrollToNodeId) return;
+
+    const board = boardRef.current;
+    const container = getScrollParent(board);
+    const el = getSortableNode(pendingScrollToNodeId);
+
+    if (!container || !el) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+
+    const top =
+      elRect.top -
+      containerRect.top +
+      container.scrollTop -
+      container.clientHeight / 2 +
+      elRect.height / 2;
+
+    container.scrollTo({
+      top,
+      behavior: "smooth",
+    });
+
+    clearPendingScrollToNodeId();
+  }, [
+    scrollable,
+    getSortableNode,
+    pendingScrollToNodeId,
+    clearPendingScrollToNodeId,
+  ]);
 
   if (!hasMounted || isLoading) {
     return <SkeletonFull />;
@@ -56,12 +105,10 @@ const RuleBoard = ({ ruleGroup, children, ...rest }: RuleBoardProps) => {
 
   return (
     <Box
-      ref={setNodeRef}
+      ref={setBoardRef}
       display="flex"
       flexDirection="column"
       gap={0}
-      flex={1}
-      minHeight={0}
       {...rest}
     >
       <DropSpacer id={`${id}::top`} position="top" groupId={id} />

--- a/src/modules/RuleBoard/RuleBoard.tsx
+++ b/src/modules/RuleBoard/RuleBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useEffect, useRef } from "react";
+import { Fragment, useRef } from "react";
 
 import Rule from "@/modules/Rule";
 import {
@@ -23,8 +23,6 @@ import useHasMounted from "@/hooks/useHasMounted";
 import RuleAgeFilter from "../RuleAgeFilter";
 import SkeletonFull from "@/components/SkeletonFull";
 import useStateManagement from "@/hooks/useStateManagement";
-import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
-import { getScrollParent } from "@/utils/html";
 import useScrollToNode from "@/hooks/useScrollToNode";
 
 interface RuleBoardProps extends BoxProps {

--- a/src/modules/RuleWrapper/RuleWrapper.tsx
+++ b/src/modules/RuleWrapper/RuleWrapper.tsx
@@ -216,6 +216,7 @@ const RuleWrapper = ({
 
   return (
     <Box
+      rule-id={id}
       data-testid="sortable-rule"
       ref={setNodeRef}
       style={sortable ? style : {}}

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -45,6 +46,12 @@ type CohortBuilderContextValue = {
 
   hoveredKey: string | null;
   setHoveredKey: (key: string | null) => void;
+
+  registerSortableNode: (id: string, node: HTMLElement | null) => void;
+  getSortableNode: (id: string) => HTMLElement | undefined;
+
+  pendingScrollToNodeId: string | null;
+  clearPendingScrollToNodeId: () => void;
 };
 
 const CohortBuilderContext = createContext<CohortBuilderContextValue | null>(
@@ -96,6 +103,35 @@ export const CohortBuilderProvider = ({
   const [active, setActive] = useState<Active | null>(null);
   const [activeNode, setActiveNode] = useState<RuleNodeType | null>(null);
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+
+  const sortableNodeRefs = useRef(new Map<string, HTMLElement>());
+
+  const registerSortableNode = useCallback(
+    (id: string, node: HTMLElement | null) => {
+      if (node) {
+        sortableNodeRefs.current.set(id, node);
+      } else {
+        sortableNodeRefs.current.delete(id);
+      }
+    },
+    [],
+  );
+
+  const getSortableNode = useCallback((id: string) => {
+    return sortableNodeRefs.current.get(id);
+  }, []);
+
+  const [pendingScrollToNodeId, setPendingScrollToNodeId] = useState<
+    string | null
+  >(null);
+
+  const createAndScroll = useCallback((create: () => RuleNodeType) => {
+    const created = create();
+
+    if (!created) return;
+
+    setPendingScrollToNodeId(created.id);
+  }, []);
 
   const onDragStart = useCallback(
     (e: DragStartEvent) => {
@@ -214,12 +250,30 @@ export const CohortBuilderProvider = ({
 
   const actions = useMemo<Action[]>(
     () => [
-      { action: createNewRule, label: "Add Rule" },
-      { action: createNewOperator, label: "Add Operator" },
-      { action: createNewAgeFilter, label: "Add Age Rule" },
-      { action: createNewGroup, label: "Add Group" },
+      {
+        action: () => createAndScroll(createNewRule),
+        label: "Add rule",
+      },
+      {
+        action: () => createAndScroll(createNewOperator),
+        label: "Add operator",
+      },
+      {
+        action: () => createAndScroll(createNewAgeFilter),
+        label: "Add age rule",
+      },
+      {
+        action: () => createAndScroll(createNewGroup),
+        label: "Add group",
+      },
     ],
-    [createNewAgeFilter, createNewRule, createNewGroup, createNewOperator],
+    [
+      createAndScroll,
+      createNewAgeFilter,
+      createNewRule,
+      createNewGroup,
+      createNewOperator,
+    ],
   );
 
   const value = useMemo(
@@ -230,8 +284,22 @@ export const CohortBuilderProvider = ({
       actions,
       hoveredKey,
       setHoveredKey,
+      registerSortableNode,
+      getSortableNode,
+      pendingScrollToNodeId,
+      clearPendingScrollToNodeId: () => setPendingScrollToNodeId(null),
     }),
-    [active, activeNode, handleContextMenu, actions, hoveredKey],
+    [
+      active,
+      activeNode,
+      handleContextMenu,
+      actions,
+      hoveredKey,
+      registerSortableNode,
+      getSortableNode,
+      pendingScrollToNodeId,
+      setPendingScrollToNodeId,
+    ],
   );
 
   return (

--- a/src/store/queryBuilderStore.ts
+++ b/src/store/queryBuilderStore.ts
@@ -105,11 +105,11 @@ export interface QueryBuilderStoreState {
     modifiers?: SelectNodeWithModifiersArgs,
   ) => void;
 
-  createNewNode: (kind: NodeKind) => void;
-  createNewRule: () => void;
-  createNewGroup: () => void;
-  createNewOperator: () => void;
-  createNewAgeFilter: () => void;
+  createNewNode: (kind: NodeKind) => RuleNodeType;
+  createNewRule: () => RuleNodeType;
+  createNewGroup: () => RuleNodeType;
+  createNewOperator: () => RuleNodeType;
+  createNewAgeFilter: () => RuleNodeType;
 
   queryAsText: string;
   getQueryFromText: (
@@ -303,16 +303,17 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
     }
   },
 
-  createNewNode: (kind: NodeKind) => {
+  createNewNode: (kind: NodeKind): RuleNodeType => {
     const fn = Creators[kind];
 
     const { queryBuilderJson, setQueryBuilderJson, setSelected } = get();
 
     const normaliseAdditions = (
       belowNeighbor?: RuleNodeType,
-    ): RuleNodeType[] => {
+    ): { additions: RuleNodeType[]; primaryNode: RuleNodeType } => {
       const produced = fn();
       const additions = Array.isArray(produced) ? produced : [produced];
+      const primaryNode = additions[0];
 
       const belowIsOperator = !!belowNeighbor && isOperator(belowNeighbor);
       const lastAdditionIsOperator = isOperator(
@@ -322,13 +323,16 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
       const suffixWithOperator =
         belowNeighbor && !belowIsOperator && !lastAdditionIsOperator;
 
-      return suffixWithOperator
-        ? [...additions, ...[createOperator()]]
-        : additions;
+      return {
+        additions: suffixWithOperator
+          ? [...additions, createOperator()]
+          : additions,
+        primaryNode,
+      };
     };
 
     const firstNode = queryBuilderJson.rules[0];
-    const toPrepend = normaliseAdditions(firstNode);
+    const { additions: toPrepend, primaryNode } = normaliseAdditions(firstNode);
 
     const rules = [...toPrepend, ...queryBuilderJson.rules];
 
@@ -341,6 +345,7 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
     );
 
     setQueryBuilderJson(updatedQuery);
+    return primaryNode;
   },
 
   createNewRule: () => get().createNewNode(NodeKind.RULE),

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,0 +1,17 @@
+const getScrollParent = (el: HTMLElement | null): HTMLElement | null => {
+  let parent = el?.parentElement ?? null;
+
+  while (parent) {
+    const { overflowY } = window.getComputedStyle(parent);
+
+    if (["auto", "scroll"].includes(overflowY)) {
+      return parent;
+    }
+
+    parent = parent.parentElement;
+  }
+
+  return null;
+};
+
+export { getScrollParent };


### PR DESCRIPTION
## Summary

* fix the maxHeight of the select datasets so that the save button is always visible

## Jira

https://hdruk.atlassian.net/browse/DP-778

## PR Type

- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence


https://github.com/user-attachments/assets/92b71944-2f8e-4171-aeef-2bfccf725d03



## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
