### PR TITLE
fix(DP-819): Search box behaviour with existing queries

### DIFF
--- a/src/components/CohortQueryInput/CohortQueryInput.test.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.test.tsx
@@ -1,0 +1,390 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import CohortQueryInput from ".";
+import MockCohortDiscoveryServiceStore from "@/store/MockCohortDiscoveryServiceStore";
+import {
+  CombinatorType,
+  OperatorType,
+  RuleLeafType,
+  RuleNodeType,
+} from "@/types/rules";
+import {
+  createRuleGroup,
+  isOperator,
+  isRuleGroup,
+  isRuleLeaf,
+} from "@/utils/rules";
+
+const setQueryBuilderJson = jest.fn();
+const getQueryFromText = jest.fn();
+const resetQueryBuilderJson = jest.fn();
+const appendError = jest.fn();
+
+const makeRule = (name: string): RuleLeafType =>
+  ({
+    id: `${name}-rule`,
+    valid: true,
+    rule: {
+      concept: {
+        concept_id: name.length,
+        name,
+        category: "Condition",
+        children: [],
+      },
+    },
+  }) satisfies RuleLeafType;
+
+const makeOperator = (combinator: CombinatorType): OperatorType =>
+  ({
+    id: `${combinator}-operator`,
+    valid: true,
+    combinator,
+  }) satisfies OperatorType;
+
+const diabetesRule = makeRule("Diabetes");
+const covidRule = makeRule("COVID-19");
+const cancerRule = makeRule("Cancer");
+const andRule = makeOperator(CombinatorType.AND);
+const orRule = makeOperator(CombinatorType.OR);
+
+const diabetesQuery = createRuleGroup([diabetesRule]);
+
+const covidQuery = createRuleGroup([covidRule]);
+
+const covidAndCancerQuery = createRuleGroup([covidRule, andRule, cancerRule]);
+
+const covidOrCancerQuery = createRuleGroup([covidRule, orRule, cancerRule]);
+
+const renderComponent = ({ queryBuilderJson = createRuleGroup([]) } = {}) => {
+  return render(
+    <MockCohortDiscoveryServiceStore
+      overrides={{
+        queryBuilder: {
+          queryBuilderJson,
+          getQueryFromText,
+          setQueryBuilderJson,
+          resetQueryBuilderJson,
+          appendError,
+          errors: [],
+          hasSelectedSyntheticDatasets: false,
+        },
+      }}
+    >
+      <CohortQueryInput queries={[]} />
+    </MockCohortDiscoveryServiceStore>,
+  );
+};
+
+const getSearchInput = () => screen.getByRole("searchbox");
+
+const submitWithEnter = async (value: string) => {
+  const user = userEvent.setup();
+
+  const input = getSearchInput();
+
+  await user.clear(input);
+  await user.type(input, value);
+  await user.keyboard("{Enter}");
+};
+
+const clickAdd = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /add/i }));
+};
+
+const clickStartFresh = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /start fresh/i }));
+};
+
+const expectRuleNode = (actual: RuleNodeType, expected: RuleNodeType) => {
+  if (isOperator(expected)) {
+    expect(isOperator(actual)).toBe(true);
+
+    if (!isOperator(actual)) return;
+
+    expect(actual.combinator).toBe(expected.combinator);
+    return;
+  }
+
+  if (isRuleLeaf(expected)) {
+    expect(isRuleLeaf(actual)).toBe(true);
+
+    if (!isRuleLeaf(actual)) return;
+
+    expect(actual?.rule?.concept?.name).toBe(expected?.rule?.concept?.name);
+    return;
+  }
+
+  if (isRuleGroup(expected)) {
+    expect(isRuleGroup(actual)).toBe(true);
+
+    if (!isRuleGroup(actual)) return;
+
+    expectRules(actual.rules, expected.rules);
+    return;
+  }
+
+  throw new Error("Unsupported expected rule node");
+};
+
+const expectRules = (
+  actualRules: RuleNodeType[],
+  expectedRules: RuleNodeType[],
+) => {
+  expect(actualRules).toHaveLength(expectedRules.length);
+
+  expectedRules.forEach((expected, index) => {
+    expectRuleNode(actualRules[index], expected);
+  });
+};
+
+describe("CohortQueryInput", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("opens the search overlay when the empty input is focused", async () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    await user.click(getSearchInput());
+
+    expect(
+      await screen.findByTestId("search-overlay-paper"),
+    ).toBeInTheDocument();
+
+    expect(await screen.findByText("Query Examples")).toBeInTheDocument();
+  });
+
+  it("does not update queryBuilderJson while typing, then updates when Enter is pressed", async () => {
+    const user = userEvent.setup();
+
+    getQueryFromText.mockResolvedValueOnce(diabetesQuery);
+
+    renderComponent();
+
+    const input = getSearchInput();
+
+    await user.type(input, "diabetes");
+
+    expect(setQueryBuilderJson).not.toHaveBeenCalled();
+
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalledWith(diabetesQuery);
+    });
+  });
+
+  it("updates queryBuilderJson when the arrow button is clicked", async () => {
+    const user = userEvent.setup();
+
+    getQueryFromText.mockResolvedValueOnce(diabetesQuery);
+
+    renderComponent();
+
+    await user.type(getSearchInput(), "diabetes");
+
+    expect(setQueryBuilderJson).not.toHaveBeenCalled();
+
+    const buttons = screen.getAllByRole("button");
+    const arrowButton = buttons[buttons.length - 1];
+
+    await user.click(arrowButton);
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalledWith(diabetesQuery);
+    });
+  });
+
+  it("replaces the existing query when Start Fresh is selected", async () => {
+    getQueryFromText.mockResolvedValueOnce(covidQuery);
+
+    renderComponent({
+      queryBuilderJson: diabetesQuery,
+    });
+
+    await clickStartFresh();
+    await submitWithEnter("covid");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalledWith(covidQuery);
+    });
+  });
+
+  it("uses AND when adding a plain query to an existing single-term query", async () => {
+    getQueryFromText.mockResolvedValueOnce(covidQuery);
+
+    renderComponent({
+      queryBuilderJson: diabetesQuery,
+    });
+
+    await clickAdd();
+    await submitWithEnter("covid");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalled();
+    });
+
+    const updatedQuery = setQueryBuilderJson.mock.calls[0][0];
+
+    const expectedRules = [covidRule, andRule, diabetesRule];
+
+    expectRules(updatedQuery.rules, expectedRules);
+  });
+
+  it("uses OR when adding a query with explicit OR to an existing single-term query", async () => {
+    getQueryFromText.mockResolvedValueOnce(covidQuery);
+
+    renderComponent({
+      queryBuilderJson: diabetesQuery,
+    });
+
+    await clickAdd();
+    await submitWithEnter("or covid");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalled();
+    });
+
+    const updatedQuery = setQueryBuilderJson.mock.calls[0][0];
+
+    expectRules(updatedQuery.rules, [covidRule, orRule, diabetesRule]);
+  });
+
+  it("adds plain diabetes to existing covid AND cancer using AND", async () => {
+    getQueryFromText.mockResolvedValueOnce(diabetesQuery);
+
+    renderComponent({
+      queryBuilderJson: covidAndCancerQuery,
+      queryAsText: "COVID-19 and Cancer",
+    });
+
+    await clickAdd();
+    await submitWithEnter("diabetes");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalled();
+    });
+
+    const updatedQuery = setQueryBuilderJson.mock.calls[0][0];
+
+    expectRules(updatedQuery.rules, [
+      diabetesRule,
+      andRule,
+      covidRule,
+      andRule,
+      cancerRule,
+    ]);
+  });
+
+  it("adds explicit AND diabetes to existing covid AND cancer without grouping", async () => {
+    getQueryFromText.mockResolvedValueOnce(diabetesQuery);
+
+    renderComponent({
+      queryBuilderJson: covidAndCancerQuery,
+    });
+
+    await clickAdd();
+    await submitWithEnter("and diabetes");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalled();
+    });
+
+    const updatedQuery = setQueryBuilderJson.mock.calls[0][0];
+
+    expectRules(updatedQuery.rules, [
+      diabetesRule,
+      andRule,
+      covidRule,
+      andRule,
+      cancerRule,
+    ]);
+  });
+
+  it("groups existing covid AND cancer when adding explicit OR diabetes", async () => {
+    getQueryFromText.mockResolvedValueOnce(diabetesQuery);
+
+    renderComponent({
+      queryBuilderJson: covidAndCancerQuery,
+    });
+
+    await clickAdd();
+    await submitWithEnter("or diabetes");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalled();
+    });
+
+    const updatedQuery = setQueryBuilderJson.mock.calls[0][0];
+
+    expect(updatedQuery.rules).toHaveLength(3);
+
+    expect(updatedQuery.rules[0]).toEqual(diabetesRule);
+
+    expect(updatedQuery.rules[1]).toEqual(
+      expect.objectContaining({
+        combinator: CombinatorType.OR,
+      }),
+    );
+
+    expect(updatedQuery.rules[2]).toEqual(
+      expect.objectContaining({
+        rules: covidAndCancerQuery.rules,
+      }),
+    );
+  });
+
+  it("adds explicit OR diabetes to existing covid OR cancer without grouping", async () => {
+    getQueryFromText.mockResolvedValueOnce(diabetesQuery);
+
+    renderComponent({
+      queryBuilderJson: covidOrCancerQuery,
+    });
+
+    await clickAdd();
+    await submitWithEnter("or diabetes");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalled();
+    });
+
+    const updatedQuery = setQueryBuilderJson.mock.calls[0][0];
+
+    expectRules(updatedQuery.rules, [
+      diabetesRule,
+      orRule,
+      covidRule,
+      orRule,
+      cancerRule,
+    ]);
+  });
+
+  it("groups existing covid OR cancer when adding explicit AND diabetes", async () => {
+    getQueryFromText.mockResolvedValueOnce(diabetesQuery);
+
+    renderComponent({
+      queryBuilderJson: covidOrCancerQuery,
+    });
+
+    await clickAdd();
+    await submitWithEnter("and diabetes");
+
+    await waitFor(() => {
+      expect(setQueryBuilderJson).toHaveBeenCalled();
+    });
+
+    const updatedQuery = setQueryBuilderJson.mock.calls[0][0];
+
+    expectRules(updatedQuery.rules, [
+      diabetesRule,
+      andRule,
+      createRuleGroup([covidRule, orRule, cancerRule]),
+    ]);
+  });
+});

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -21,12 +21,16 @@ import { useDefaults } from "@/providers/DefaultProvider";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import InlineChoiceButton from "./InlineChoiceButton";
 import { CombinatorType } from "@/types/rules";
+import AddCircleIcon from "@mui/icons-material/AddCircle";
 
 type FormValues = {
   cohortQueryInput: string;
 };
 
-type QueryMode = "fresh" | "append" | null;
+enum QueryMode {
+  FRESH = "fresh",
+  APPEND = "append",
+}
 
 const MIN_SEARCH_LENGTH = 3;
 const STALE_TIME = 60_000;
@@ -60,7 +64,7 @@ const CohortQueryInput = ({
 
   const queryClient = useQueryClient();
 
-  const [queryMode, setQueryMode] = useState<QueryMode>(null);
+  const [queryMode, setQueryMode] = useState<QueryMode | null>(null);
   const [openSearchOverlap, setOpenSearchOverlap] = useState(false);
 
   const programmaticValueRef = useRef<string | null>(null);
@@ -80,12 +84,33 @@ const CohortQueryInput = ({
     mode: "onChange",
   });
 
-  const hasExistingQuery = useMemo(
-    () => queryBuilderJson.rules.length > 0,
-    [queryBuilderJson.rules.length],
-  );
+  const isAppendMode = queryMode === QueryMode.APPEND;
 
-  const requiresQueryModeChoice = hasExistingQuery && queryMode === null;
+  const rulesKey = useMemo(
+    () => JSON.stringify(queryBuilderJson.rules),
+    [queryBuilderJson.rules],
+  );
+  const ruleCount = queryBuilderJson.rules.length;
+  const requiresQueryModeChoice = ruleCount && queryMode === null;
+
+  useEffect(() => {
+    /*
+     * Intentional exception to react-hooks/set-state-in-effect:
+     * queryMode/openSearchOverlap are transient local UI states tied to the
+     * current query builder contents.
+     *
+     * If the rules change outside this component (which they can do),
+     * the previous mode may no longer be valid.
+     * Resetting it forces the user back through the mode choice when
+     * requiresQueryModeChoice becomes true.
+     *
+     * Functional setters prevent redundant updates if already reset.
+     */
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setQueryMode((current) => (current === null ? current : null));
+
+    setOpenSearchOverlap((current) => (current ? false : current));
+  }, [rulesKey]);
 
   const resetQuery = useCallback(() => {
     clearFormErrors();
@@ -173,7 +198,7 @@ const CohortQueryInput = ({
         staleTime: STALE_TIME,
       });
 
-      if (queryMode === "append") {
+      if (queryMode === QueryMode.APPEND) {
         const existingRules = convertToGroup
           ? [createRuleGroup(queryBuilderJson.rules)]
           : queryBuilderJson.rules;
@@ -229,7 +254,6 @@ const CohortQueryInput = ({
 
   const shouldApplyImmediately = (v: string) => v.trim() === "";
 
-  // debounce live input at a shorter interval to prefetch it
   useDebounce(liveInput, {
     delay: defaults.searchPrefetch,
     shouldApplyImmediately,
@@ -329,12 +353,22 @@ const CohortQueryInput = ({
 
           const searchDisabled = showChoicePrompt || !!error || !hasInput;
 
+          const StartIcon = isAppendMode ? AddCircleIcon : SearchIcon;
+
+          const startIconSx = {
+            ml: 2,
+            color: isAppendMode ? "success.main" : "inherit",
+          };
+
+          const showSearchOverlay =
+            !showChoicePrompt && !isAppendMode && openSearchOverlap;
+
           return (
             <Box display="flex" flexDirection="row" sx={{ gap: 1 }}>
               <Box ref={anchorRef} sx={{ flex: 1 }}>
                 <SearchBox
                   {...field}
-                  startIcon={<SearchIcon fontSize="medium" sx={{ ml: 2 }} />}
+                  startIcon={<StartIcon fontSize="medium" sx={startIconSx} />}
                   collapsible={false}
                   error={isDirty && !!error}
                   type="search"
@@ -346,7 +380,7 @@ const CohortQueryInput = ({
                         <InlineChoiceButton
                           onMouseDown={(e) => e.preventDefault()}
                           onClick={() => {
-                            setQueryMode("fresh");
+                            setQueryMode(QueryMode.FRESH);
                             setOpenSearchOverlap(true);
                           }}
                         >
@@ -357,8 +391,8 @@ const CohortQueryInput = ({
                           sx={{ px: 0.5 }}
                           onMouseDown={(e) => e.preventDefault()}
                           onClick={() => {
-                            setQueryMode("append");
-                            setOpenSearchOverlap(true);
+                            setQueryMode(QueryMode.APPEND);
+                            setOpenSearchOverlap(false);
                           }}
                         >
                           Add
@@ -377,7 +411,7 @@ const CohortQueryInput = ({
                   endIcon={<ArrowForwardIcon />}
                   onClickEndAdornment={onSubmit}
                   onFocus={() => {
-                    if (!showChoicePrompt) {
+                    if (!showChoicePrompt && !isAppendMode) {
                       setOpenSearchOverlap(true);
                     }
                   }}
@@ -390,7 +424,7 @@ const CohortQueryInput = ({
 
                     field.onChange(e);
 
-                    if (e.target.value) {
+                    if (e.target.value || isAppendMode) {
                       setOpenSearchOverlap(false);
                     }
                   }}
@@ -398,7 +432,7 @@ const CohortQueryInput = ({
 
                 <SearchOverlay
                   queries={queries}
-                  open={!showChoicePrompt && openSearchOverlap}
+                  open={showSearchOverlay}
                   anchorEl={anchorRef.current}
                   options={placeholders.map((label) => ({
                     label,

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -8,7 +8,12 @@ import SearchBox from "../SearchBox";
 import SearchIcon from "@mui/icons-material/Search";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { useDebounce } from "@/hooks/useDebounce";
-import { createOperator, RuleErrors } from "@/utils/rules";
+import {
+  createOperator,
+  createRuleGroup,
+  getFirstTopLevelCombinator,
+  RuleErrors,
+} from "@/utils/rules";
 import { EXAMPLES } from "@/config/queryExamples";
 import { Query } from "@/types/api";
 import SearchOverlay from "./SearchOverlay";
@@ -122,26 +127,36 @@ const CohortQueryInput = ({
       const parseQueryInput = (raw: string) => {
         const trimmed = raw.trim();
 
+        const groupLevelCombinator = getFirstTopLevelCombinator(
+          queryBuilderJson.rules,
+        );
+
         const match = trimmed.match(/^(and|or)\b\s*/i);
         if (!match) {
           return {
             query: trimmed,
-            combinator: CombinatorType.AND,
+            combinator: groupLevelCombinator,
+            convertToGroup: false,
           };
         }
 
+        const requestedCombinator =
+          match[1].toLowerCase() === "or"
+            ? CombinatorType.OR
+            : CombinatorType.AND;
+
         return {
           query: trimmed.slice(match[0].length).trim(),
-          combinator:
-            match[1].toLowerCase() === "or"
-              ? CombinatorType.OR
-              : CombinatorType.AND,
+          combinator: requestedCombinator,
+          convertToGroup:
+            queryBuilderJson.rules.length > 0 &&
+            requestedCombinator !== groupLevelCombinator,
         };
       };
 
       if (requiresQueryModeChoice) return;
 
-      const { query: q, combinator } = parseQueryInput(raw);
+      const { query: q, combinator, convertToGroup } = parseQueryInput(raw);
 
       if (programmaticValueRef.current === q) return;
       if (q.length < MIN_SEARCH_LENGTH) return;
@@ -159,12 +174,16 @@ const CohortQueryInput = ({
       });
 
       if (queryMode === "append") {
+        const existingRules = convertToGroup
+          ? [createRuleGroup(queryBuilderJson.rules)]
+          : queryBuilderJson.rules;
+
         setQueryBuilderJson({
           ...queryBuilderJson,
           rules: [
             ...queryJson.rules,
             createOperator(combinator),
-            ...queryBuilderJson.rules,
+            ...existingRules,
           ],
           warnings: [
             ...(queryBuilderJson.warnings ?? []),

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -91,7 +91,7 @@ const CohortQueryInput = ({
     [queryBuilderJson.rules],
   );
   const ruleCount = queryBuilderJson.rules.length;
-  const requiresQueryModeChoice = ruleCount && queryMode === null;
+  const requiresQueryModeChoice = !!ruleCount && queryMode === null;
 
   useEffect(() => {
     /*
@@ -353,10 +353,9 @@ const CohortQueryInput = ({
 
           const searchDisabled = showChoicePrompt || !!error || !hasInput;
 
-          const StartIcon = isAppendMode ? AddCircleIcon : SearchIcon;
+          const EndIcon = isAppendMode ? AddCircleIcon : ArrowForwardIcon;
 
-          const startIconSx = {
-            ml: 2,
+          const endIconSx = {
             color: isAppendMode ? "success.main" : "inherit",
           };
 
@@ -368,7 +367,7 @@ const CohortQueryInput = ({
               <Box ref={anchorRef} sx={{ flex: 1 }}>
                 <SearchBox
                   {...field}
-                  startIcon={<StartIcon fontSize="medium" sx={startIconSx} />}
+                  startIcon={<SearchIcon fontSize="medium" sx={{ ml: 2 }} />}
                   collapsible={false}
                   error={isDirty && !!error}
                   type="search"
@@ -408,7 +407,7 @@ const CohortQueryInput = ({
                   readOnly={showChoicePrompt}
                   disabled={searchDisabled}
                   showEndIcon
-                  endIcon={<ArrowForwardIcon />}
+                  endIcon={<EndIcon sx={endIconSx} />}
                   onClickEndAdornment={onSubmit}
                   onFocus={() => {
                     if (!showChoicePrompt && !isAppendMode) {

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -149,7 +149,7 @@ const CohortQueryInput = ({
           query: trimmed.slice(match[0].length).trim(),
           combinator: requestedCombinator,
           convertToGroup:
-            queryBuilderJson.rules.length > 0 &&
+            queryBuilderJson.rules.length > 1 &&
             requestedCombinator !== groupLevelCombinator,
         };
       };

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -254,6 +254,7 @@ const CohortQueryInput = ({
 
   const shouldApplyImmediately = (v: string) => v.trim() === "";
 
+  // debounce live input at a shorter interval to prefetch it
   useDebounce(liveInput, {
     delay: defaults.searchPrefetch,
     shouldApplyImmediately,

--- a/src/components/CohortQueryInput/SearchOverlay.tsx
+++ b/src/components/CohortQueryInput/SearchOverlay.tsx
@@ -20,6 +20,7 @@ const SearchOverlay = ({ queries, options, anchorEl, open }: Props) => {
 
   return (
     <Popper
+      data-testid="search-overlay"
       open={open}
       anchorEl={anchorEl}
       placement="bottom-start"
@@ -27,6 +28,7 @@ const SearchOverlay = ({ queries, options, anchorEl, open }: Props) => {
       style={{ zIndex: 2000 }}
     >
       <Paper
+        data-testid="search-overlay-paper"
         sx={{
           width: anchorEl?.clientWidth,
           boxShadow: 3,

--- a/src/components/RuleTimeframeSelector/RuleTimeframeSelector.tsx
+++ b/src/components/RuleTimeframeSelector/RuleTimeframeSelector.tsx
@@ -79,7 +79,7 @@ const RuleTimeframeSelector = ({
     disableOpenPicker: readOnly ? true : false,
   };
 
-  const { verb } = getDomainPhrase(rule.rule.concept?.category);
+  const { verbPast } = getDomainPhrase(rule.rule.concept?.category);
 
   const parseIsoToDayjs = useCallback(
     (iso: string | null) => (iso ? dayjs(iso) : null),
@@ -101,7 +101,6 @@ const RuleTimeframeSelector = ({
         flex={flex}
       >
         {title && <CustomH1>{title}</CustomH1>}
-
         <SingleBoundSelector<string, Dayjs>
           constraint={rule.timeConstraint ?? []}
           constraintOperator={
@@ -120,7 +119,7 @@ const RuleTimeframeSelector = ({
           parse={parseIsoToDayjs}
           serialise={serialiseDayjsToIso}
           readOnly={readOnly}
-          anyLabel={`${capitaliseFirstLetter(verb)} at any time`}
+          anyLabel={`${capitaliseFirstLetter(verbPast)} at any time`}
           renderPicker={({ value, onChange }) => (
             <DatePicker
               {...commonPickerProps}
@@ -130,12 +129,12 @@ const RuleTimeframeSelector = ({
           )}
           renderReadOnlyLabel={({ operator, value }) =>
             value
-              ? `${capitaliseFirstLetter(verb)} ${
+              ? `${capitaliseFirstLetter(verbPast)} ${
                   operator === SingleSidedOperator.GREATER_THAN
                     ? "after"
                     : "before"
                 } ${value.format("MM-YYYY")}`
-              : `${capitaliseFirstLetter(verb)} at any time`
+              : `${capitaliseFirstLetter(verbPast)} at any time`
           }
         />
         {children}

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -188,6 +188,7 @@ const SearchConcepts = ({
   return (
     <Box>
       <SearchBar
+        placeholder="Term search..."
         loading={isLoading}
         onSearch={onSearch}
         filters={

--- a/src/modules/Guidance/Guidance.tsx
+++ b/src/modules/Guidance/Guidance.tsx
@@ -42,7 +42,7 @@ import { AddChipProps } from "@/components/AddChip/AddChip";
 import AddTimeFrameButton from "@/components/AddTimeFrameButton";
 import RuleTimeframeSelector from "@/components/RuleTimeframeSelector";
 import { CustomH1, CustomH2 } from "@/components/GuidanceHeaders";
-import { getDomain, getDomainPhrase } from "@/utils/omop";
+import { getDomain, getDomainPastPhrase, getDomainPhrase } from "@/utils/omop";
 import DeleteTimeFrameButton from "@/components/DeleteTimeFrameButton";
 import DeleteMenuItem, {
   DeleteMenuItemProps,
@@ -318,7 +318,8 @@ const Guidance = () => {
 
       const concept = selectedNode?.rule?.concept;
       const category = concept?.category || "";
-      const { verb, past } = getDomainPhrase(category);
+      const { verb } = getDomainPhrase(category);
+      const past = getDomainPastPhrase(category);
       const domain = getDomain(concept);
 
       return (

--- a/src/types/omop.ts
+++ b/src/types/omop.ts
@@ -24,15 +24,20 @@ export enum OmopTableName {
 
 export type DomainPhrase = {
   verb: string;
-  past: string;
+  verbPast: string;
+  pastPrefix: string;
   noun: string;
   include: string;
   exclude: string;
 };
 
+export const getPastPhrase = ({ pastPrefix, verbPast }: DomainPhrase): string =>
+  [pastPrefix, verbPast].filter(Boolean).join(" ");
+
 export const DEFAULT_DOMAIN_PHRASE: DomainPhrase = {
   verb: "record",
-  past: "was recorded",
+  verbPast: "recorded",
+  pastPrefix: "was",
   noun: "record",
   include: "were associated with",
   exclude: "were not associated with",
@@ -41,91 +46,104 @@ export const DEFAULT_DOMAIN_PHRASE: DomainPhrase = {
 export const DOMAIN_PHRASES: Record<OmopTableName, DomainPhrase> = {
   [OmopTableName.Sex]: {
     verb: "record",
-    past: "was recorded",
+    verbPast: "recorded",
+    pastPrefix: "was",
     noun: "sex",
     include: "were recorded as being",
     exclude: "were not recorded as being",
   },
   [OmopTableName.Condition]: {
     verb: "diagnose",
-    past: "was diagnosed",
+    verbPast: "diagnosed",
+    pastPrefix: "was",
     noun: "diagnosis",
     include: "were diagnosed with",
     exclude: "were not diagnosed with",
   },
   [OmopTableName.Drug]: {
     verb: "take",
-    past: "was taken",
+    verbPast: "taken",
+    pastPrefix: "was",
     noun: "medication",
     include: "received",
     exclude: "did not receive",
   },
   [OmopTableName.Measurement]: {
     verb: "measure",
-    past: "was measured",
+    verbPast: "measured",
+    pastPrefix: "was",
     noun: "measurement",
     include: "were measured with",
     exclude: "were not measured with",
   },
   [OmopTableName.Observation]: {
     verb: "observe",
-    past: "was observed",
+    verbPast: "observed",
+    pastPrefix: "was",
     noun: "observation",
     include: "were observed with",
     exclude: "were not observed with",
   },
   [OmopTableName.Procedure]: {
     verb: "perform",
-    past: "was performed",
+    verbPast: "performed",
+    pastPrefix: "was",
     noun: "procedure",
     include: "underwent",
     exclude: "did not undergo",
   },
   [OmopTableName.Device]: {
     verb: "expose",
-    past: "was exposed",
+    verbPast: "exposed",
+    pastPrefix: "was",
     noun: "device",
     include: "were exposed to",
     exclude: "were not exposed to",
   },
   [OmopTableName.Visit]: {
     verb: "visit",
-    past: "had a visit",
+    verbPast: "visit",
+    pastPrefix: "had a",
     noun: "visit",
     include: "had",
     exclude: "did not have",
   },
   [OmopTableName.Death]: {
     verb: "die",
-    past: "died",
+    verbPast: "died",
+    pastPrefix: "",
     noun: "death",
     include: "died",
     exclude: "did not die",
   },
   [OmopTableName.Specimen]: {
     verb: "collect",
-    past: "was collected",
+    verbPast: "collected",
+    pastPrefix: "was",
     noun: "specimen",
     include: "had a specimen collected",
     exclude: "did not have a specimen collected",
   },
   [OmopTableName.Gender]: {
     verb: "record",
-    past: "was recorded",
+    verbPast: "recorded",
+    pastPrefix: "was",
     noun: "gender",
     include: "were recorded as being",
     exclude: "were not recorded as being",
   },
   [OmopTableName.Race]: {
     verb: "record",
-    past: "was recorded",
+    verbPast: "recorded",
+    pastPrefix: "was",
     noun: "race",
     include: "were recorded as being",
     exclude: "were not recorded as being",
   },
   [OmopTableName.Ethnicity]: {
     verb: "record",
-    past: "was recorded",
+    verbPast: "recorded",
+    pastPrefix: "was",
     noun: "ethnicity",
     include: "were recorded as being",
     exclude: "were not recorded as being",

--- a/src/utils/omop.ts
+++ b/src/utils/omop.ts
@@ -27,6 +27,12 @@ const getDomainPhrase = (category?: string): DomainPhrase => {
   );
 };
 
+const getPastPhrase = ({ pastPrefix, verbPast }: DomainPhrase): string =>
+  [pastPrefix, verbPast].filter(Boolean).join(" ");
+
+const getDomainPastPhrase = (category?: string): string =>
+  getPastPhrase(getDomainPhrase(category));
+
 const getDomain = (
   concept: Concept | Concept[] | null,
   options: { useDefault?: boolean } = {},
@@ -45,4 +51,4 @@ const getDomain = (
   return capitaliseFirstLetter(mapped);
 };
 
-export { codesToOption, getDomainPhrase, getDomain };
+export { codesToOption, getDomainPhrase, getDomainPastPhrase, getDomain };

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -137,7 +137,8 @@ const queryToText = (
     exclude: boolean,
   ): { verb: string | null; text: string | null; category?: string } => {
     const c = rule.concept;
-    if (!c) return { verb: null, text: null, category: undefined };
+
+    if (!c) return { verb: null, text: "[blank]", category: undefined };
 
     if (isSingleConcept(c)) {
       const verb = getVerb(c.category, exclude);

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -160,6 +160,13 @@ export const isInGroup = (id: string, boardIndex: BoardIndex) => {
   return !boardContents?.includes(id);
 };
 
+export const getFirstTopLevelCombinator = (
+  rules: RuleNodeType[],
+): CombinatorType => {
+  const combinatorRule = rules.find((r) => isOperator(r));
+  return combinatorRule?.combinator ?? CombinatorType.AND;
+};
+
 export const findById = (
   root: RuleNodeType,
   id: string,


### PR DESCRIPTION
## Summary

* When you click on ‘Add’ in the NLP box, then the query example dropdown doesn’t open
* Search button's 'arrow' icon changes to a '+' icon when in the 'Add' state after the steps above.
   * The ‘+' changes back to the arrow icon when user is out of 'Add’ state
   * Click on ‘Clear Query’ should clear the ‘Add’ state and bring user back to default ‘new query’ state
   * Refreshing the page should clear the ‘Add’ state and bring user back to default ‘new query’ state
* When you click on ‘Start fresh’ in the NLP box, then click on a query example in the dropdown, the dropdown should close automatically


## Jira

https://hdruk.atlassian.net/browse/DP-819
https://hdruk.atlassian.net/browse/DP-820
https://hdruk.atlassian.net/browse/DP-818
https://hdruk.atlassian.net/browse/DP-800

## PR Type

- [ ] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence


https://github.com/user-attachments/assets/32f22b18-5679-4a12-b854-bdfded8ab22f



## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
