### PR TITLE
fix(DP-722): auto-focus search input for newly added rule blocks

### DIFF
--- a/src/hooks/useNodeActions.ts
+++ b/src/hooks/useNodeActions.ts
@@ -44,8 +44,7 @@ const useNodeActions = (
     }),
   );
 
-  // DP-722: lets us hand the just-created rule's id to the scroll+focus signal so the right-click "Add Rule" path matches the Insert menu's behaviour.
-  const { setPendingScrollToNodeId } = useCohortBuilderContext();
+  const { createAndScroll } = useCohortBuilderContext();
 
   const selectedNodeIds = useMemo(
     () => getSelectedOrdered(selected, queryBuilderJson),
@@ -163,24 +162,25 @@ const useNodeActions = (
   // Right-click group action that adds a new rule at the top of a group.
   const handleCreateNewRule = useCallback(() => {
     if (!groupRules) return;
-    // DP-722: keep a reference to the inserted rule so we can point the shared scroll/focus signal at this exact rule after the state update.
-    const newRule = createRule();
-    const newRules = [newRule, createOperator(), ...groupRules];
+    createAndScroll(() => {
+      const newRule = createRule();
+      const newRules = [newRule, createOperator(), ...groupRules];
 
-    setQueryBuilderJson(
-      updateById(queryBuilderJson, id, (node) => ({
-        ...node,
-        rules: newRules,
-      })),
-    );
-    // DP-722: trigger the same scroll-and-focus flow as the Insert menu.
-    setPendingScrollToNodeId(newRule.id);
+      setQueryBuilderJson(
+        updateById(queryBuilderJson, id, (node) => ({
+          ...node,
+          rules: newRules,
+        })),
+      );
+
+      return newRule;
+    });
   }, [
+    createAndScroll,
     id,
     groupRules,
     queryBuilderJson,
     setQueryBuilderJson,
-    setPendingScrollToNodeId,
   ]);
 
   const handleCreateNewAgeFilter = useCallback(() => {

--- a/src/hooks/useNodeActions.ts
+++ b/src/hooks/useNodeActions.ts
@@ -17,6 +17,7 @@ import {
   createAgeFilter,
 } from "@/utils/rules";
 import { useCallback, useMemo } from "react";
+import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
 
 export interface RightClickAction {
   action: () => void;
@@ -42,6 +43,10 @@ const useNodeActions = (
       selected: qb.selected,
     }),
   );
+
+  // DP-722: lets us hand the just-created rule's id to the scroll+focus signal so the right-click "Add Rule" path matches the Insert menu's behaviour.
+  const { setPendingScrollToNodeId } = useCohortBuilderContext();
+
   const selectedNodeIds = useMemo(
     () => getSelectedOrdered(selected, queryBuilderJson),
     [selected, queryBuilderJson],
@@ -154,9 +159,13 @@ const useNodeActions = (
   }, [id, queryBuilderJson, setQueryBuilderJson]);
 
   const groupRules = node && isRuleGroup(node) ? node.rules : undefined;
+
+  // Right-click group action that adds a new rule at the top of a group.
   const handleCreateNewRule = useCallback(() => {
     if (!groupRules) return;
-    const newRules = [createRule(), createOperator(), ...groupRules];
+    // DP-722: keep a reference to the inserted rule so we can point the shared scroll/focus signal at this exact rule after the state update.
+    const newRule = createRule();
+    const newRules = [newRule, createOperator(), ...groupRules];
 
     setQueryBuilderJson(
       updateById(queryBuilderJson, id, (node) => ({
@@ -164,7 +173,15 @@ const useNodeActions = (
         rules: newRules,
       })),
     );
-  }, [id, groupRules, queryBuilderJson, setQueryBuilderJson]);
+    // DP-722: trigger the same scroll-and-focus flow as the Insert menu.
+    setPendingScrollToNodeId(newRule.id);
+  }, [
+    id,
+    groupRules,
+    queryBuilderJson,
+    setQueryBuilderJson,
+    setPendingScrollToNodeId,
+  ]);
 
   const handleCreateNewAgeFilter = useCallback(() => {
     if (!groupRules) return;

--- a/src/hooks/useNodeActions.ts
+++ b/src/hooks/useNodeActions.ts
@@ -175,37 +175,41 @@ const useNodeActions = (
 
       return newRule;
     });
-  }, [
-    createAndScroll,
-    id,
-    groupRules,
-    queryBuilderJson,
-    setQueryBuilderJson,
-  ]);
+  }, [createAndScroll, id, groupRules, queryBuilderJson, setQueryBuilderJson]);
 
   const handleCreateNewAgeFilter = useCallback(() => {
     if (!groupRules) return;
-    const newRules = [createAgeFilter(), createOperator(), ...groupRules];
+    createAndScroll(() => {
+      const newAgeFilter = createAgeFilter();
+      const newRules = [newAgeFilter, createOperator(), ...groupRules];
 
-    setQueryBuilderJson(
-      updateById(queryBuilderJson, id, (node) => ({
-        ...node,
-        rules: newRules,
-      })),
-    );
-  }, [id, groupRules, queryBuilderJson, setQueryBuilderJson]);
+      setQueryBuilderJson(
+        updateById(queryBuilderJson, id, (node) => ({
+          ...node,
+          rules: newRules,
+        })),
+      );
+
+      return newAgeFilter;
+    });
+  }, [createAndScroll, id, groupRules, queryBuilderJson, setQueryBuilderJson]);
 
   const handleCreateNewOperator = useCallback(() => {
     if (!groupRules) return;
-    const newRules = [createOperator(), ...groupRules];
+    createAndScroll(() => {
+      const newOperator = createOperator();
+      const newRules = [newOperator, ...groupRules];
 
-    setQueryBuilderJson(
-      updateById(queryBuilderJson, id, (node) => ({
-        ...node,
-        rules: newRules,
-      })),
-    );
-  }, [id, groupRules, queryBuilderJson, setQueryBuilderJson]);
+      setQueryBuilderJson(
+        updateById(queryBuilderJson, id, (node) => ({
+          ...node,
+          rules: newRules,
+        })),
+      );
+
+      return newOperator;
+    });
+  }, [createAndScroll, id, groupRules, queryBuilderJson, setQueryBuilderJson]);
 
   const actions = [
     { action: handleDeleteRule, label: "Delete" },

--- a/src/hooks/useScrollToNode.ts
+++ b/src/hooks/useScrollToNode.ts
@@ -14,56 +14,31 @@ const useScrollToNode = ({ enabled, boardRef }: UseScrollToNodeArgs) => {
   useEffect(() => {
     if (!enabled || !pendingScrollToNodeId) return;
 
-    let frameId = 0;
-    let attempts = 0;
-    const maxAttempts = 10;
+    const board = boardRef.current;
+    const container = getScrollParent(board);
+    const el = getSortableNode(pendingScrollToNodeId);
 
-    const tryScrollAndFocus = () => {
-      const board = boardRef.current;
-      const container = getScrollParent(board);
-      const el = getSortableNode(pendingScrollToNodeId);
+    if (!container || !el) return;
 
-      if (!container || !el) {
-        if (attempts++ < maxAttempts) {
-          frameId = requestAnimationFrame(tryScrollAndFocus);
-          return;
-        }
+    const input = el.querySelector<HTMLInputElement>("input");
+    const containerRect = container.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
 
-        clearPendingScrollToNodeId();
-        return;
-      }
+    const top =
+      elRect.top -
+      containerRect.top +
+      container.scrollTop -
+      container.clientHeight / 2 +
+      elRect.height / 2;
 
-      const containerRect = container.getBoundingClientRect();
-      const elRect = el.getBoundingClientRect();
+    container.scrollTo({
+      top,
+      behavior: "smooth",
+    });
 
-      const top =
-        elRect.top -
-        containerRect.top +
-        container.scrollTop -
-        container.clientHeight / 2 +
-        elRect.height / 2;
+    input?.focus({ preventScroll: true });
 
-      container.scrollTo({
-        top,
-        behavior: "smooth",
-      });
-
-      const input = el.querySelector<HTMLInputElement>("input");
-
-      if (!input && attempts++ < maxAttempts) {
-        frameId = requestAnimationFrame(tryScrollAndFocus);
-        return;
-      }
-
-      input?.focus({ preventScroll: true });
-      clearPendingScrollToNodeId();
-    };
-
-    tryScrollAndFocus();
-
-    return () => {
-      cancelAnimationFrame(frameId);
-    };
+    clearPendingScrollToNodeId();
   }, [
     enabled,
     boardRef,

--- a/src/hooks/useScrollToNode.ts
+++ b/src/hooks/useScrollToNode.ts
@@ -21,6 +21,8 @@ const useScrollToNode = ({ enabled, boardRef }: UseScrollToNodeArgs) => {
     if (!container || !el) return;
 
     const input = el.querySelector<HTMLInputElement>("input");
+    input?.focus({ preventScroll: true });
+
     const containerRect = container.getBoundingClientRect();
     const elRect = el.getBoundingClientRect();
 
@@ -35,8 +37,6 @@ const useScrollToNode = ({ enabled, boardRef }: UseScrollToNodeArgs) => {
       top,
       behavior: "smooth",
     });
-
-    input?.focus({ preventScroll: true });
 
     clearPendingScrollToNodeId();
   }, [

--- a/src/hooks/useScrollToNode.ts
+++ b/src/hooks/useScrollToNode.ts
@@ -14,31 +14,56 @@ const useScrollToNode = ({ enabled, boardRef }: UseScrollToNodeArgs) => {
   useEffect(() => {
     if (!enabled || !pendingScrollToNodeId) return;
 
-    const board = boardRef.current;
-    const container = getScrollParent(board);
-    const el = getSortableNode(pendingScrollToNodeId);
+    let frameId = 0;
+    let attempts = 0;
+    const maxAttempts = 10;
 
-    if (!container || !el) return;
+    const tryScrollAndFocus = () => {
+      const board = boardRef.current;
+      const container = getScrollParent(board);
+      const el = getSortableNode(pendingScrollToNodeId);
 
-    const input = el.querySelector<HTMLInputElement>("input");
-    const containerRect = container.getBoundingClientRect();
-    const elRect = el.getBoundingClientRect();
+      if (!container || !el) {
+        if (attempts++ < maxAttempts) {
+          frameId = requestAnimationFrame(tryScrollAndFocus);
+          return;
+        }
 
-    const top =
-      elRect.top -
-      containerRect.top +
-      container.scrollTop -
-      container.clientHeight / 2 +
-      elRect.height / 2;
+        clearPendingScrollToNodeId();
+        return;
+      }
 
-    container.scrollTo({
-      top,
-      behavior: "smooth",
-    });
+      const containerRect = container.getBoundingClientRect();
+      const elRect = el.getBoundingClientRect();
 
-    input?.focus({ preventScroll: true });
-    
-    clearPendingScrollToNodeId();
+      const top =
+        elRect.top -
+        containerRect.top +
+        container.scrollTop -
+        container.clientHeight / 2 +
+        elRect.height / 2;
+
+      container.scrollTo({
+        top,
+        behavior: "smooth",
+      });
+
+      const input = el.querySelector<HTMLInputElement>("input");
+
+      if (!input && attempts++ < maxAttempts) {
+        frameId = requestAnimationFrame(tryScrollAndFocus);
+        return;
+      }
+
+      input?.focus({ preventScroll: true });
+      clearPendingScrollToNodeId();
+    };
+
+    tryScrollAndFocus();
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
   }, [
     enabled,
     boardRef,

--- a/src/hooks/useScrollToNode.ts
+++ b/src/hooks/useScrollToNode.ts
@@ -20,6 +20,7 @@ const useScrollToNode = ({ enabled, boardRef }: UseScrollToNodeArgs) => {
 
     if (!container || !el) return;
 
+    const input = el.querySelector<HTMLInputElement>("input");
     const containerRect = container.getBoundingClientRect();
     const elRect = el.getBoundingClientRect();
 
@@ -35,6 +36,8 @@ const useScrollToNode = ({ enabled, boardRef }: UseScrollToNodeArgs) => {
       behavior: "smooth",
     });
 
+    input?.focus({ preventScroll: true });
+    
     clearPendingScrollToNodeId();
   }, [
     enabled,

--- a/src/modules/Rule/Rule.tsx
+++ b/src/modules/Rule/Rule.tsx
@@ -1,7 +1,7 @@
 import { Chip, Box } from "@mui/material";
 import SearchConcepts from "@/components/SearchConcepts";
 import { Concept } from "@/types/api";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import ConceptChip from "@/components/ConceptChip";
 import { RuleLeafType, SingleSidedOperator } from "@/types/rules";
 
@@ -19,6 +19,7 @@ import { RuleWrapperProps } from "../RuleWrapper/RuleWrapper";
 import useNodeActions from "@/hooks/useNodeActions";
 import InvalidRule from "@/components/InvalidRule";
 import { getDomain } from "@/utils/omop";
+import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
 
 export interface RuleProps extends Omit<
   RuleWrapperProps,
@@ -119,6 +120,21 @@ const Rule = ({ rule, groupId, ...rest }: RuleProps) => {
 
   const { actions } = useNodeActions(rule);
 
+  // DP-722: auto-focus the "Term search..." input when this rule block is newly created.
+  // We piggyback on the existing "pendingScrollToNodeId" signal.
+  // Only this Rule component reacts to it, because groups and operators do not render this search input.
+  const { pendingScrollToNodeId } = useCohortBuilderContext();
+  const searchBoxRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (pendingScrollToNodeId !== id) return;
+
+    const input =
+      searchBoxRef.current?.querySelector<HTMLInputElement>("input");
+    // preventScroll lets the existing smooth-scroll-to-new-node animation run uninterrupted.
+    input?.focus({ preventScroll: true });
+  }, [pendingScrollToNodeId, id]);
+
   return (
     <RuleWrapper
       node={rule}
@@ -131,7 +147,7 @@ const Rule = ({ rule, groupId, ...rest }: RuleProps) => {
         ) : null
       }
       render={() => (
-        <Box py={1}>
+        <Box py={1} ref={searchBoxRef}>
           {isEmptyRule(rule) ? (
             <SearchConcepts onClick={onClick} />
           ) : (

--- a/src/modules/Rule/Rule.tsx
+++ b/src/modules/Rule/Rule.tsx
@@ -1,7 +1,7 @@
 import { Chip, Box } from "@mui/material";
 import SearchConcepts from "@/components/SearchConcepts";
 import { Concept } from "@/types/api";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import ConceptChip from "@/components/ConceptChip";
 import { RuleLeafType, SingleSidedOperator } from "@/types/rules";
 
@@ -19,7 +19,6 @@ import { RuleWrapperProps } from "../RuleWrapper/RuleWrapper";
 import useNodeActions from "@/hooks/useNodeActions";
 import InvalidRule from "@/components/InvalidRule";
 import { getDomain } from "@/utils/omop";
-import { useCohortBuilderContext } from "@/providers/CohortBuilderProvider";
 
 export interface RuleProps extends Omit<
   RuleWrapperProps,
@@ -120,21 +119,6 @@ const Rule = ({ rule, groupId, ...rest }: RuleProps) => {
 
   const { actions } = useNodeActions(rule);
 
-  // DP-722: auto-focus the "Term search..." input when this rule block is newly created.
-  // We piggyback on the existing "pendingScrollToNodeId" signal.
-  // Only this Rule component reacts to it, because groups and operators do not render this search input.
-  const { pendingScrollToNodeId } = useCohortBuilderContext();
-  const searchBoxRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (pendingScrollToNodeId !== id) return;
-
-    const input =
-      searchBoxRef.current?.querySelector<HTMLInputElement>("input");
-    // preventScroll lets the existing smooth-scroll-to-new-node animation run uninterrupted.
-    input?.focus({ preventScroll: true });
-  }, [pendingScrollToNodeId, id]);
-
   return (
     <RuleWrapper
       node={rule}
@@ -147,7 +131,7 @@ const Rule = ({ rule, groupId, ...rest }: RuleProps) => {
         ) : null
       }
       render={() => (
-        <Box py={1} ref={searchBoxRef}>
+        <Box py={1}>
           {isEmptyRule(rule) ? (
             <SearchConcepts onClick={onClick} />
           ) : (

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -59,12 +59,9 @@ type CohortBuilderContextValue = {
 
   registerSortableNode: (id: string, node: HTMLElement | null) => void;
   getSortableNode: (id: string) => HTMLElement | undefined;
+  createAndScroll: (create: () => RuleNodeType) => RuleNodeType | undefined;
 
   pendingScrollToNodeId: string | null;
-
-  // Previously the context only exposed clearPendingScrollToNodeId (which sets it to null).
-  // To let the right-click "Add Rule" path on groups also write to the signal, we expose the full setter.
-  setPendingScrollToNodeId: (id: string | null) => void;
   clearPendingScrollToNodeId: () => void;
 };
 
@@ -146,14 +143,14 @@ export const CohortBuilderProvider = ({
 
     if (!created) return;
 
-    // DP-722: the shared scroll/focus signal normally targets the newly created node itself.
-    // For "Add group", that would target the group card, but we want to focus the first rule's "Term search..." input inside the new group.
-    // So we redirect the signal to that top rule instead, and other add actions still target the created node as usual.
+    // The shared scroll/focus signal usually targets the newly created node.
+    // When doing "Add group", we want to target the first inner rule so that we can focus its input instead of the group card.
     const target = isRuleGroup(created)
       ? (created.rules.find(isRuleLeaf) ?? created)
       : created;
 
     setPendingScrollToNodeId(target.id);
+    return created;
   }, []);
 
   const onDragStart = useCallback(
@@ -317,8 +314,8 @@ export const CohortBuilderProvider = ({
       setHoveredKey,
       registerSortableNode,
       getSortableNode,
+      createAndScroll,
       pendingScrollToNodeId,
-      setPendingScrollToNodeId,
       clearPendingScrollToNodeId: () => setPendingScrollToNodeId(null),
     }),
     [
@@ -329,8 +326,8 @@ export const CohortBuilderProvider = ({
       hoveredKey,
       registerSortableNode,
       getSortableNode,
+      createAndScroll,
       pendingScrollToNodeId,
-      setPendingScrollToNodeId,
     ],
   );
 

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -61,10 +61,6 @@ type CohortBuilderContextValue = {
   getSortableNode: (id: string) => HTMLElement | undefined;
 
   pendingScrollToNodeId: string | null;
-
-  // Previously the context only exposed clearPendingScrollToNodeId (which sets it to null).
-  // To let the right-click "Add Rule" path on groups also write to the signal, we expose the full setter.
-  setPendingScrollToNodeId: (id: string | null) => void;
   clearPendingScrollToNodeId: () => void;
 };
 
@@ -146,14 +142,14 @@ export const CohortBuilderProvider = ({
 
     if (!created) return;
 
-    // DP-722: the shared scroll/focus signal normally targets the newly created node itself.
-    // For "Add group", that would target the group card, but we want to focus the first rule's "Term search..." input inside the new group.
-    // So we redirect the signal to that top rule instead, and other add actions still target the created node as usual.
+    // The shared scroll/focus signal usually targets the newly created node.
+    // When doing "Add group", we want to target the first inner rule so that we can focus its input instead of the group card.
     const target = isRuleGroup(created)
       ? (created.rules.find(isRuleLeaf) ?? created)
       : created;
 
     setPendingScrollToNodeId(target.id);
+    return created;
   }, []);
 
   const onDragStart = useCallback(
@@ -317,8 +313,8 @@ export const CohortBuilderProvider = ({
       setHoveredKey,
       registerSortableNode,
       getSortableNode,
+      createAndScroll,
       pendingScrollToNodeId,
-      setPendingScrollToNodeId,
       clearPendingScrollToNodeId: () => setPendingScrollToNodeId(null),
     }),
     [
@@ -329,8 +325,8 @@ export const CohortBuilderProvider = ({
       hoveredKey,
       registerSortableNode,
       getSortableNode,
+      createAndScroll,
       pendingScrollToNodeId,
-      setPendingScrollToNodeId,
     ],
   );
 

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -31,8 +31,6 @@ import useRightClickMenu from "@/hooks/useRightClickMenu";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { RuleNodeType } from "@/types/rules";
 
-// isRuleGroup and isRuleLeaf are tiny utility functions (in utils/rules.ts) that check if a node has a rules array (group) or a rule property (leaf rule).
-// We need them in createAndScroll.
 import {
   findById,
   isRuleGroup,

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -5,7 +5,6 @@ import React, {
   useCallback,
   useContext,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import {
@@ -117,22 +116,29 @@ export const CohortBuilderProvider = ({
   const [activeNode, setActiveNode] = useState<RuleNodeType | null>(null);
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 
-  const sortableNodeRefs = useRef(new Map<string, HTMLElement>());
+  const [sortableNodes, setSortableNodes] = useState(
+    () => new Map<string, HTMLElement>(),
+  );
 
   const registerSortableNode = useCallback(
     (id: string, node: HTMLElement | null) => {
-      if (node) {
-        sortableNodeRefs.current.set(id, node);
-      } else {
-        sortableNodeRefs.current.delete(id);
-      }
+      setSortableNodes((prev) => {
+        const next = new Map(prev);
+        if (node) {
+          next.set(id, node);
+        } else {
+          next.delete(id);
+        }
+        return next;
+      });
     },
     [],
   );
 
-  const getSortableNode = useCallback((id: string) => {
-    return sortableNodeRefs.current.get(id);
-  }, []);
+  const getSortableNode = useCallback(
+    (id: string) => sortableNodes.get(id),
+    [sortableNodes],
+  );
 
   const [pendingScrollToNodeId, setPendingScrollToNodeId] = useState<
     string | null

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -147,8 +147,6 @@ export const CohortBuilderProvider = ({
 
     if (!created) return;
 
-    // The shared scroll/focus signal usually targets the newly created node.
-    // When doing "Add group", we want to target the first inner rule so that we can focus its input instead of the group card.
     const target = isRuleGroup(created)
       ? (created.rules.find(isRuleLeaf) ?? created)
       : created;

--- a/src/providers/CohortBuilderProvider.tsx
+++ b/src/providers/CohortBuilderProvider.tsx
@@ -31,7 +31,16 @@ import RightClickMenu from "@/components/RightClickMenu/RightClickMenu";
 import useRightClickMenu from "@/hooks/useRightClickMenu";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { RuleNodeType } from "@/types/rules";
-import { findById, moveItemIntoGroup } from "@/utils/rules";
+
+// isRuleGroup and isRuleLeaf are tiny utility functions (in utils/rules.ts) that check if a node has a rules array (group) or a rule property (leaf rule).
+// We need them in createAndScroll.
+import {
+  findById,
+  isRuleGroup,
+  isRuleLeaf,
+  moveItemIntoGroup,
+} from "@/utils/rules";
+
 import useFeatures from "@/hooks/useFeatures";
 
 type Action = {
@@ -52,6 +61,10 @@ type CohortBuilderContextValue = {
   getSortableNode: (id: string) => HTMLElement | undefined;
 
   pendingScrollToNodeId: string | null;
+
+  // Previously the context only exposed clearPendingScrollToNodeId (which sets it to null).
+  // To let the right-click "Add Rule" path on groups also write to the signal, we expose the full setter.
+  setPendingScrollToNodeId: (id: string | null) => void;
   clearPendingScrollToNodeId: () => void;
 };
 
@@ -133,7 +146,14 @@ export const CohortBuilderProvider = ({
 
     if (!created) return;
 
-    setPendingScrollToNodeId(created.id);
+    // DP-722: the shared scroll/focus signal normally targets the newly created node itself.
+    // For "Add group", that would target the group card, but we want to focus the first rule's "Term search..." input inside the new group.
+    // So we redirect the signal to that top rule instead, and other add actions still target the created node as usual.
+    const target = isRuleGroup(created)
+      ? (created.rules.find(isRuleLeaf) ?? created)
+      : created;
+
+    setPendingScrollToNodeId(target.id);
   }, []);
 
   const onDragStart = useCallback(
@@ -298,6 +318,7 @@ export const CohortBuilderProvider = ({
       registerSortableNode,
       getSortableNode,
       pendingScrollToNodeId,
+      setPendingScrollToNodeId,
       clearPendingScrollToNodeId: () => setPendingScrollToNodeId(null),
     }),
     [


### PR DESCRIPTION
## Summary

This change makes adding rules feel smoother. Whenever a new rule is created, the "Term search..." box is ready to type into straight away instead of needing an extra click. It also adds “scroll to newly created node” behaviour for the relevant right-click actions on group nodes, including newly added rules inside groups.

As part of this, a dependency issue that was preventing focus from working correctly on some creation paths was also fixed (Thanks Calum for spotting it)

Manual test cases passed:

- Insert > Add rule on an empty board scrolls to the new rule and focuses its input
- Repeated Insert > Add rule with no groups scrolls to each newly added rule and focuses its input
- Insert > Add group scrolls to the new group and focuses the top rule in that group
- Insert > Add rule when a group already exists scrolls to the new top rule and focuses its input
- Right-click group Add Rule scrolls to the new top rule in that group and focuses its input
- Right-click group Add Age Rule scrolls to the new age rule without changing focus
- Right-click group Add And/Or scrolls to the new operator without changing focus
- Adding a rule and deleting it immediately produces no console errors

## Jira

https://hdruk.atlassian.net/browse/DP-722

## PR Type

- [X] `feat`
- [X] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [X] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

https://github.com/user-attachments/assets/3485af0e-9557-4a19-8de6-36802d02e123

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
