### PR TITLE
fix(DP-761): remove grey background after hierarchy rename

### DIFF
--- a/src/components/HierarchyItem/HierarchyItem.style.ts
+++ b/src/components/HierarchyItem/HierarchyItem.style.ts
@@ -33,9 +33,10 @@ export const listItemButtonSx =
         : "none",
     "&.Mui-focusVisible": {
       bgcolor: isSelected ? "background.default" : "transparent",
-    },
-    "&.Mui-focusVisible:hover": {
-      bgcolor: isSelected ? "background.default" : "highlight.main",
+
+      "&:hover": {
+        bgcolor: isSelected ? "background.default" : "highlight.main",
+      },
     },
 
     ...(isOver && {

--- a/src/components/HierarchyItem/HierarchyItem.style.ts
+++ b/src/components/HierarchyItem/HierarchyItem.style.ts
@@ -31,6 +31,12 @@ export const listItemButtonSx =
       : isHovered
         ? "highlight.main"
         : "none",
+    "&.Mui-focusVisible": {
+      bgcolor: isSelected ? "background.default" : "transparent",
+    },
+    "&.Mui-focusVisible:hover": {
+      bgcolor: isSelected ? "background.default" : "highlight.main",
+    },
 
     ...(isOver && {
       "&::after": {

--- a/src/components/HierarchyItem/HierarchyItem.tsx
+++ b/src/components/HierarchyItem/HierarchyItem.tsx
@@ -99,6 +99,11 @@ export const HierarchyItem = ({
 
   const { setHoverRef, isHighlighted } = useHoverable<HTMLDivElement>(node.id);
 
+  const handleRenameCommit = (name: string) => {
+    setNodeName(node, name);
+    deselect(node.id);
+  };
+
   const content = (
     <ListItemButton
       ref={setHoverRef}
@@ -126,7 +131,7 @@ export const HierarchyItem = ({
         primary={
           <EditableText
             defaultValue={nodeName}
-            onCommit={(name) => setNodeName(node, name)}
+            onCommit={handleRenameCommit}
             typographyProps={{
               component: "span",
             }}


### PR DESCRIPTION
## Summary

Fixed the Hierarchy panel rename flow where pressing Enter after renaming a rule or group could leave the row with a grey background even though it was no longer selected.

Turns out the issue was caused by MUI `ListItemButton`'s `Mui-focusVisible` state, which is applied for keyboard accessibility after committing with Enter.

The final fix deselects the node after pressing Enter or clicking away/blurring and overrides `Mui-focusVisible` only for hierarchy items so unselected rows return to a transparent/default background, selected rows keep their selected background, and hovered rows still show the normal blue hover highlight.

## Jira

https://hdruk.atlassian.net/browse/DP-761

## PR Type

- [ ] `feat`
- [X] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [X] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [X] Verified locally that pressing Enter after renaming a hierarchy item returns the row to the default background when not hovered
- [X] Verified the normal blue hover highlight still appears after renaming
- [X] Verified selected hierarchy items keep their selected background
- [X] `npx eslint src/components/HierarchyItem/HierarchyItem.tsx src/components/HierarchyItem/HierarchyItem.style.ts` passes

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

https://github.com/user-attachments/assets/762a99a1-aca6-499e-88b3-9babd97d5e32

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->