### PR TITLE
fix(DP-858): keep rule search results fixed height with vertical scroll (subtask of DP-721)

### DIFF
--- a/src/components/SearchConcepts/SearchConcepts.test.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SearchConcepts from "./SearchConcepts";
 import ApplicationModeProvider from "@/providers/ApplicationModeProvider";
@@ -87,5 +87,28 @@ describe("SearchConcepts", () => {
     const calledWith = onClick.mock.calls[0][0];
     expect(calledWith).toHaveProperty("concept_id");
     expect(calledWith).toHaveProperty("name");
+  });
+
+  it("loads more results after clicking Show more", async () => {
+    renderComponent();
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "Chronic{enter}");
+
+    const initialItems = await screen.findAllByTestId("concept-item");
+    expect(initialItems).toHaveLength(20);
+    expect(screen.getByRole("button", { name: /show more/i })).toHaveTextContent(
+      "Show more (20 / 22)",
+    );
+
+    const showMore = await screen.findByRole("button", { name: /show more/i });
+    await act(async () => {
+      showMore.click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("concept-item")).toHaveLength(22);
+      expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
+    });
   });
 });

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -66,6 +66,7 @@ const SearchConcepts = ({
     ...(selected ?? {}),
   });
 
+  const [isShowingMore, setIsShowingMore] = useState(false);
   const [nonSyntheticOptions, setNonSyntheticOptions] = useState<Concept[]>([]);
   const [syntheticOptions, setSyntheticOptions] = useState<Concept[]>([]);
   const [noOptionsFound, setNoOptionsFound] = useState(false);
@@ -184,12 +185,22 @@ const SearchConcepts = ({
   );
 
   const handleShowMore = useCallback(async () => {
+    if (isLoading || isShowingMore) return;
+
     const nextPerPage =
       (activeResult?.per_page ?? perPage) + DEFAULT_CODES_PER_PAGE;
     shouldScrollToResultsEndRef.current = true;
+    setIsShowingMore(true);
     setPerPage(nextPerPage);
-    await onSearch(lastQueryRef.current, true, nextPerPage);
-  }, [activeResult, perPage, onSearch]);
+
+    try {
+      await onSearch(lastQueryRef.current, true, nextPerPage);
+    } catch (error) {
+      shouldScrollToResultsEndRef.current = false;
+      setIsShowingMore(false);
+      throw error;
+    }
+  }, [activeResult, perPage, onSearch, isLoading, isShowingMore]);
 
   useLayoutEffect(() => {
     if (!shouldScrollToResultsEndRef.current) return;
@@ -199,6 +210,7 @@ const SearchConcepts = ({
       block: "end",
       behavior: "smooth",
     });
+    requestAnimationFrame(() => setIsShowingMore(false));
   }, [activeResult?.per_page, visibleOptions.length]);
 
   return (
@@ -258,6 +270,7 @@ const SearchConcepts = ({
         <Box sx={{ mt: 1 }}>
           <Button
             variant="text"
+            disabled={isLoading || isShowingMore}
             onClick={(e) => {
               e.stopPropagation();
               e.preventDefault();

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -205,7 +205,7 @@ const SearchConcepts = ({
   useEffect(() => {
     const current = activeResult?.per_page ?? 0;
     if (current > prevPerPageRef.current && prevPerPageRef.current > 0) {
-      resultsContainerRef.current?.scrollTo({
+      resultsContainerRef.current?.scrollTo?.({
         top: resultsContainerRef.current.scrollHeight,
         behavior: "smooth",
       });

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -40,6 +40,17 @@ interface SearchConceptsProps {
 
 const SEARCH_RESULTS_MAX_HEIGHT = 420;
 
+const searchResultsSx = {
+  alignItems: "stretch",
+  flexDirection: "column",
+  flexWrap: "nowrap",
+  maxHeight: SEARCH_RESULTS_MAX_HEIGHT,
+  mt: 2,
+  overflowX: "hidden",
+  overflowY: "auto",
+  pr: 1,
+} as const;
+
 const SearchConcepts = ({
   domain,
   selected,
@@ -230,16 +241,7 @@ const SearchConcepts = ({
       />
       <FormGroup
         data-testid="search-concepts-results"
-        sx={{
-          alignItems: "stretch",
-          flexDirection: "column",
-          flexWrap: "nowrap",
-          maxHeight: SEARCH_RESULTS_MAX_HEIGHT,
-          mt: 2,
-          overflowX: "hidden",
-          overflowY: "auto",
-          pr: 1,
-        }}
+        sx={searchResultsSx}
       >
         {multiple && visibleOptions.length > 0 && (
           <>

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -238,21 +238,21 @@ const SearchConcepts = ({
             {syntheticOptions.map(renderConceptItem)}
           </>
         )}
-        {activeResult && activeResult.per_page < activeResult.total && (
-          <Box>
-            <Button
-              variant="text"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                handleShowMore();
-              }}
-            >
-              Show more ({activeResult.per_page} / {activeResult.total})
-            </Button>
-          </Box>
-        )}
       </FormGroup>
+      {activeResult && activeResult.per_page < activeResult.total && (
+        <Box sx={{ mt: 1 }}>
+          <Button
+            variant="text"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              handleShowMore();
+            }}
+          >
+            Show more ({activeResult.per_page} / {activeResult.total})
+          </Button>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -72,7 +72,7 @@ const SearchConcepts = ({
   > | null>(null);
 
   const lastQueryRef = useRef<string>("");
-  const resultsEndRef = useRef<HTMLDivElement | null>(null);
+  const resultsContainerRef = useRef<HTMLDivElement | null>(null);
   const prevPerPageRef = useRef(0);
   const initialSelectedRef = useRef<Record<number, boolean>>({
     ...(selected ?? {}),
@@ -204,17 +204,12 @@ const SearchConcepts = ({
   }, [activeResult, perPage, onSearch, isLoading]);
 
   useEffect(() => {
-    const current = activeResult?.per_page;
-    if (!current) {
-      prevPerPageRef.current = 0;
-      return;
-    }
+    const current = activeResult?.per_page ?? 0;
     if (current > prevPerPageRef.current && prevPerPageRef.current > 0) {
-      const id = requestAnimationFrame(() => {
-        resultsEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+      resultsContainerRef.current?.scrollTo({
+        top: resultsContainerRef.current.scrollHeight,
+        behavior: "smooth",
       });
-      prevPerPageRef.current = current;
-      return () => cancelAnimationFrame(id);
     }
     prevPerPageRef.current = current;
   }, [activeResult?.per_page]);
@@ -235,6 +230,7 @@ const SearchConcepts = ({
         debounceMs={400}
       />
       <FormGroup
+        ref={resultsContainerRef}
         data-testid="search-concepts-results"
         sx={searchResultsSx}
       >
@@ -261,7 +257,6 @@ const SearchConcepts = ({
             {syntheticOptions.map(renderConceptItem)}
           </>
         )}
-        <Box ref={resultsEndRef} aria-hidden />
       </FormGroup>
       {activeResult && activeResult.per_page < activeResult.total && (
         <Box sx={{ mt: 1 }}>

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -196,12 +196,11 @@ const SearchConcepts = ({
   );
 
   const handleShowMore = useCallback(() => {
-    if (isLoading) return;
     const nextPerPage =
       (activeResult?.per_page ?? perPage) + DEFAULT_CODES_PER_PAGE;
     setPerPage(nextPerPage);
     onSearch(lastQueryRef.current, true, nextPerPage);
-  }, [activeResult, perPage, onSearch, isLoading]);
+  }, [activeResult, perPage, onSearch]);
 
   useEffect(() => {
     const current = activeResult?.per_page ?? 0;

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -9,7 +9,7 @@ import {
   useCallback,
   useRef,
   useMemo,
-  useLayoutEffect,
+  useEffect,
 } from "react";
 import {
   Checkbox,
@@ -73,12 +73,11 @@ const SearchConcepts = ({
 
   const lastQueryRef = useRef<string>("");
   const resultsEndRef = useRef<HTMLDivElement | null>(null);
-  const shouldScrollToResultsEndRef = useRef(false);
+  const prevPerPageRef = useRef(0);
   const initialSelectedRef = useRef<Record<number, boolean>>({
     ...(selected ?? {}),
   });
 
-  const [isShowingMore, setIsShowingMore] = useState(false);
   const [nonSyntheticOptions, setNonSyntheticOptions] = useState<Concept[]>([]);
   const [syntheticOptions, setSyntheticOptions] = useState<Concept[]>([]);
   const [noOptionsFound, setNoOptionsFound] = useState(false);
@@ -196,34 +195,29 @@ const SearchConcepts = ({
     />
   );
 
-  const handleShowMore = useCallback(async () => {
-    if (isLoading || isShowingMore) return;
-
+  const handleShowMore = useCallback(() => {
+    if (isLoading) return;
     const nextPerPage =
       (activeResult?.per_page ?? perPage) + DEFAULT_CODES_PER_PAGE;
-    shouldScrollToResultsEndRef.current = true;
-    setIsShowingMore(true);
     setPerPage(nextPerPage);
+    onSearch(lastQueryRef.current, true, nextPerPage);
+  }, [activeResult, perPage, onSearch, isLoading]);
 
-    try {
-      await onSearch(lastQueryRef.current, true, nextPerPage);
-    } catch (error) {
-      shouldScrollToResultsEndRef.current = false;
-      setIsShowingMore(false);
-      throw error;
+  useEffect(() => {
+    const current = activeResult?.per_page;
+    if (!current) {
+      prevPerPageRef.current = 0;
+      return;
     }
-  }, [activeResult, perPage, onSearch, isLoading, isShowingMore]);
-
-  useLayoutEffect(() => {
-    if (!shouldScrollToResultsEndRef.current) return;
-
-    shouldScrollToResultsEndRef.current = false;
-    resultsEndRef.current?.scrollIntoView({
-      block: "end",
-      behavior: "smooth",
-    });
-    requestAnimationFrame(() => setIsShowingMore(false));
-  }, [activeResult?.per_page, visibleOptions.length]);
+    if (current > prevPerPageRef.current && prevPerPageRef.current > 0) {
+      const id = requestAnimationFrame(() => {
+        resultsEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+      });
+      prevPerPageRef.current = current;
+      return () => cancelAnimationFrame(id);
+    }
+    prevPerPageRef.current = current;
+  }, [activeResult?.per_page]);
 
   return (
     <Box>
@@ -273,7 +267,7 @@ const SearchConcepts = ({
         <Box sx={{ mt: 1 }}>
           <Button
             variant="text"
-            disabled={isLoading || isShowingMore}
+            disabled={isLoading}
             onClick={(e) => {
               e.stopPropagation();
               e.preventDefault();

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -22,7 +22,10 @@ import {
 import { ConceptItem, ConceptItemProps } from "./ConceptItem";
 import useUserStore from "@/hooks/useUserStore";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
-import { DEFAULT_CODES_PER_PAGE } from "@/config/defaults";
+import {
+  DEFAULT_CODES_PER_PAGE,
+  DEFAULT_SEARCH_RESULTS_MAX_HEIGHT,
+} from "@/config/defaults";
 import useFeatures from "@/hooks/useFeatures";
 
 interface SlotProps {
@@ -38,13 +41,11 @@ interface SearchConceptsProps {
   slotProps?: SlotProps;
 }
 
-const SEARCH_RESULTS_MAX_HEIGHT = 420;
-
 const searchResultsSx = {
   alignItems: "stretch",
   flexDirection: "column",
   flexWrap: "nowrap",
-  maxHeight: SEARCH_RESULTS_MAX_HEIGHT,
+  maxHeight: DEFAULT_SEARCH_RESULTS_MAX_HEIGHT,
   mt: 2,
   overflowX: "hidden",
   overflowY: "auto",

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -37,6 +37,8 @@ interface SearchConceptsProps {
   slotProps?: SlotProps;
 }
 
+const SEARCH_RESULTS_MAX_HEIGHT = 420;
+
 const SearchConcepts = ({
   domain,
   selected,
@@ -200,7 +202,19 @@ const SearchConcepts = ({
         }
         debounceMs={400}
       />
-      <FormGroup sx={{ mt: 2 }}>
+      <FormGroup
+        data-testid="search-concepts-results"
+        sx={{
+          alignItems: "stretch",
+          flexDirection: "column",
+          flexWrap: "nowrap",
+          maxHeight: SEARCH_RESULTS_MAX_HEIGHT,
+          mt: 2,
+          overflowX: "hidden",
+          overflowY: "auto",
+          pr: 1,
+        }}
+      >
         {multiple && visibleOptions.length > 0 && (
           <>
             <FormControlLabel

--- a/src/components/SearchConcepts/SearchConcepts.tsx
+++ b/src/components/SearchConcepts/SearchConcepts.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useRef,
   useMemo,
+  useLayoutEffect,
 } from "react";
 import {
   Checkbox,
@@ -59,6 +60,8 @@ const SearchConcepts = ({
   > | null>(null);
 
   const lastQueryRef = useRef<string>("");
+  const resultsEndRef = useRef<HTMLDivElement | null>(null);
+  const shouldScrollToResultsEndRef = useRef(false);
   const initialSelectedRef = useRef<Record<number, boolean>>({
     ...(selected ?? {}),
   });
@@ -180,12 +183,23 @@ const SearchConcepts = ({
     />
   );
 
-  const handleShowMore = useCallback(() => {
+  const handleShowMore = useCallback(async () => {
     const nextPerPage =
       (activeResult?.per_page ?? perPage) + DEFAULT_CODES_PER_PAGE;
+    shouldScrollToResultsEndRef.current = true;
     setPerPage(nextPerPage);
-    onSearch(lastQueryRef.current, true, nextPerPage);
+    await onSearch(lastQueryRef.current, true, nextPerPage);
   }, [activeResult, perPage, onSearch]);
+
+  useLayoutEffect(() => {
+    if (!shouldScrollToResultsEndRef.current) return;
+
+    shouldScrollToResultsEndRef.current = false;
+    resultsEndRef.current?.scrollIntoView({
+      block: "end",
+      behavior: "smooth",
+    });
+  }, [activeResult?.per_page, visibleOptions.length]);
 
   return (
     <Box>
@@ -238,6 +252,7 @@ const SearchConcepts = ({
             {syntheticOptions.map(renderConceptItem)}
           </>
         )}
+        <Box ref={resultsEndRef} aria-hidden />
       </FormGroup>
       {activeResult && activeResult.per_page < activeResult.total && (
         <Box sx={{ mt: 1 }}>

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -12,6 +12,7 @@ export const DEFAULT_MAX_INVALID_REASONS = 4;
 export const DEFAULT_SEARCH_PREFETCH = 500;
 export const DEFAULT_SEARCH_WAIT_TIME = 400;
 export const DEFAULT_SEARCH_SUGGESTION_ROTATION = 2000;
+export const DEFAULT_SEARCH_RESULTS_MAX_HEIGHT = 420;
 
 export const DEFAULT_STATUS_LABELS: Record<string, string> = {
   ok: "Successful",


### PR DESCRIPTION
## Summary

Added a fixed max height to the rule block concept search results so large result sets scroll inside the rule block instead of expanding the whole component vertically.

Also moved the “Show more” button below the results list to better match the Figma design, and prevented repeated “Show more” presses to avoid spam until the expanded results have fetched, rendered, and scrolled into view.

## Jira

This PR corresponds to this ticket:
https://hdruk.atlassian.net/browse/DP-858

...which is a part of the main "Improve Rule Block UI" ticket:
https://hdruk.atlassian.net/browse/DP-721

## PR Type

- [ ] `feat`
- [X] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

### Before:
<img width="1240" height="850" alt="image" src="https://github.com/user-attachments/assets/3aaa74a4-bb7d-4226-bf56-b1c611673421" />

### After:
(note: this screenshot has the `query-builder-show-concept-stats` flag enabled):

https://github.com/user-attachments/assets/76e8de0c-bbc6-47c0-b8f1-3fdf847d79f2

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
