### PR TITLE
feat(DP-265): enable collection hosts table sorting

### DIFF
--- a/src/actions/collectionHost/getCustodianCollectionHosts.ts
+++ b/src/actions/collectionHost/getCustodianCollectionHosts.ts
@@ -1,16 +1,18 @@
 "use server";
 
 import { getCollectionHostTag, TAG_COLLECTION_HOSTS } from "@/config/tags";
-import { apiGet } from "@/lib/apiClient";
+import { apiGet, CachedGetArgs } from "@/lib/apiClient";
 import { API_ROUTES } from "@/lib/apiRoutes";
 import { ApiResponse, CollectionHost } from "@/types/api";
 
 const getCustodianCollectionHosts = async (
   custodianPid: string,
+  args?: Omit<CachedGetArgs, "url">,
 ): Promise<ApiResponse<CollectionHost[]>> => {
   return await apiGet<ApiResponse<CollectionHost[]>>({
     url: API_ROUTES.custodianCollectionHosts(custodianPid),
     tags: [TAG_COLLECTION_HOSTS, getCollectionHostTag(custodianPid)],
+    ...args,
   });
 };
 

--- a/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostTab.tsx
+++ b/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostTab.tsx
@@ -1,6 +1,8 @@
 import { Box, Skeleton } from "@mui/material";
 import CollectionHostAdmin from "./CollectionHostAdmin";
 import getCustodianCollectionHosts from "@/actions/collectionHost/getCustodianCollectionHosts";
+import { ApiSearchParams } from "@/types/api";
+import { buildCollectionHostParams } from "@/utils/params";
 
 export const CollectionHostsSkeleton = () => (
   <Box sx={{ height: "100%", p: 2 }}>
@@ -11,11 +13,14 @@ export const CollectionHostsSkeleton = () => (
 
 const CollectionHostsTab = async ({
   custodianPid,
+  searchParams,
 }: {
   custodianPid: string;
+  searchParams: ApiSearchParams;
 }) => {
+  const params = buildCollectionHostParams(searchParams);
   const { data: collectionHosts } =
-    await getCustodianCollectionHosts(custodianPid);
+    await getCustodianCollectionHosts(custodianPid, { params });
 
   return (
     <CollectionHostAdmin pid={custodianPid} collectionHosts={collectionHosts} />

--- a/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostsTable.tsx
+++ b/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostsTable.tsx
@@ -6,6 +6,7 @@ import { Box, Chip } from "@mui/material";
 import { Dispatch, SetStateAction, useMemo } from "react";
 import Table from "@/components/Table";
 import { routes } from "@/config/routes";
+import SortButton from "@/components/SortButton";
 
 interface CollectionHostsTableProps {
   collectionHosts: CollectionHost[];
@@ -72,9 +73,19 @@ const CollectionHostsTable = ({
           titleProps: {
             title: "Collection Hosts",
             subTitle: "All",
+            children: <SortButton field="name" />,
+            wrapperSx: {
+              sx: {
+                display: "flex",
+                alignItems: "center",
+                flexWrap: "nowrap",
+              },
+            },
           },
         }}
-        rightAction={{ deleteProps: { onClick: onDelete } }}
+        rightAction={{
+          deleteProps: { onClick: onDelete },
+        }}
       />
     </Box>
   );

--- a/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/page.tsx
+++ b/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/page.tsx
@@ -31,7 +31,10 @@ const CustodianAdminPage = async ({
       href: routes.teamHosts(custodianPid),
       page: (
         <Suspense fallback={<CollectionHostsSkeleton />}>
-          <CollectionHostsTab custodianPid={custodianPid} />
+          <CollectionHostsTab
+            custodianPid={custodianPid}
+            searchParams={apiSearchParams}
+          />
         </Suspense>
       ),
     },

--- a/src/hooks/useTable.tsx
+++ b/src/hooks/useTable.tsx
@@ -15,6 +15,7 @@ export const useTable = <TData extends MRT_RowData>({
   columns,
   data,
   enableRowSelection = true,
+  enableSorting = false,
   ...rest
 }: MRT_TableOptions<TData>) => {
   const hydratedColumns = useMemo<MRT_ColumnDef<TData>[]>(
@@ -24,6 +25,7 @@ export const useTable = <TData extends MRT_RowData>({
             {
               id: "custom-row-select",
               header: "select",
+              enableSorting: false,
               Header: ({ table }) => (
                 <Tooltip title="Select all">
                   <SquareCheckbox
@@ -58,7 +60,7 @@ export const useTable = <TData extends MRT_RowData>({
     columns: hydratedColumns,
     data,
     enablePagination: false,
-    enableSorting: false,
+    enableSorting,
     enableFilters: false,
     enableColumnActions: false,
     enableDensityToggle: false,

--- a/src/utils/params.ts
+++ b/src/utils/params.ts
@@ -1,4 +1,5 @@
 import {
+  ApiSearchParams,
   CollectionsSearchParams,
   ConceptSearchParams,
   QueryHistorySearchParams,
@@ -45,6 +46,12 @@ export const buildCollectionParams = (
   };
 
   return buildSearchParams(params);
+};
+
+export const buildCollectionHostParams = (searchParams: ApiSearchParams) => {
+  const { sort } = searchParams ?? {};
+
+  return buildSearchParams({ sort });
 };
 
 export const buildQueryHistoryParams = (


### PR DESCRIPTION
## Summary

Added a sort button for the collection hosts to the right of "Collection Hosts / All" text as shown in the Figma design.

The sorting logic itself is reused from the existing Query History `SortButton`, and the Collection Hosts table now uses URL-driven server-side sorting so sort state is preserved in the URL and survives page reloads.

A small backend change was required, more info in the related API PR:
https://github.com/HDRUK/cohort-discovery-service-api/pull/255

## Jira

https://hdruk.atlassian.net/browse/DP-265

## PR Type

- [ ] `fix`
- [X] `feat`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [X] API integration changes (`src/actions/*`)
- [X] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [X] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

https://github.com/user-attachments/assets/49fc97bd-8ece-4a9e-939e-46ef28e660f5

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->