### PR TITLE
fix(DP-890): Cleanup code for Age Slider 

### DIFF
--- a/src/components/RuleAgeSelector/AgeInput.tsx
+++ b/src/components/RuleAgeSelector/AgeInput.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { FormControlLabel, TextField } from "@mui/material";
+import { useState } from "react";
+import { clamp } from "@/utils/numbers";
+
+function AgeInput({
+  value,
+  onChange,
+  minAge,
+  maxAge,
+}: {
+  value: number | null;
+  onChange: (v: number | null) => void;
+  minAge: number;
+  maxAge: number;
+}) {
+  const [draft, setDraft] = useState<string>(value != null ? String(value) : "");
+  const [lastValue, setLastValue] = useState<number | null>(value);
+
+  if (lastValue !== value) {
+    setLastValue(value);
+    setDraft(value != null ? String(value) : "");
+  }
+
+  const commit = () => {
+    if (draft === "") {
+      onChange(null);
+      return;
+    }
+    const n = Number(draft);
+    if (!Number.isNaN(n)) onChange(clamp(n, minAge, maxAge));
+  };
+
+  return (
+    <FormControlLabel
+      sx={{ m: 0 }}
+      control={
+        <TextField
+          size="small"
+          type="number"
+          value={draft}
+          slotProps={{ htmlInput: { min: minAge, max: maxAge } }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit();
+          }}
+        />
+      }
+      slotProps={{ typography: { sx: { mx: 1 } } }}
+      label="Years"
+    />
+  );
+}
+
+export default AgeInput;

--- a/src/components/RuleAgeSelector/RuleAgeSelector.tsx
+++ b/src/components/RuleAgeSelector/RuleAgeSelector.tsx
@@ -1,30 +1,12 @@
 "use client";
 
-import {
-  FormControlLabel,
-  Paper,
-  Slider,
-  Stack,
-  TextField,
-} from "@mui/material";
-import { ReactNode, useMemo, useState } from "react";
-import { isAgeFilter, isRuleLeaf, updateById } from "@/utils/rules";
-import {
-  AgeFilterType,
-  RuleLeafType,
-  SingleSidedOperator,
-} from "@/types/rules";
-import { CustomH1 } from "@/components/GuidanceHeaders";
+import { ReactNode } from "react";
+import { AgeFilterType, RuleLeafType } from "@/types/rules";
 import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
 import useFeatures from "@/hooks/useFeatures";
-import useQueryBuilder from "@/hooks/useQueryBuilder";
-
-import SingleBoundSelector, {
-  NullablePair,
-} from "@/components/SingleBoundSelector";
-import { clamp } from "@/utils/numbers";
-import { collapsibleGuidanceKey } from "@/utils/queryBuilder";
-import HoverableDiv from "@/components/HoverableDiv";
+import { isRuleLeaf } from "@/utils/rules";
+import RuleAgeSelectorSingleBound from "./RuleAgeSelectorSingleBound";
+import RuleAgeSelectorSlider from "./RuleAgeSelectorSlider";
 
 export interface RuleAgeSelectorProps {
   children?: ReactNode;
@@ -36,41 +18,6 @@ export interface RuleAgeSelectorProps {
   flex?: boolean;
 }
 
-export const RuleAgeSelectorReadOnly = ({
-  from,
-  to,
-  minAge,
-  maxAge,
-}: {
-  from: number;
-  to: number;
-  minAge: number;
-  maxAge: number;
-}) => {
-  let label: string;
-
-  if (from === minAge && to === maxAge) {
-    label = "Any age";
-  } else if (from === minAge) {
-    label = `Age < ${to}`;
-  } else if (to === maxAge) {
-    label = `Age ≥ ${from}`;
-  } else {
-    label = `Age ${from} - ${to}`;
-  }
-
-  return (
-    <Paper
-      sx={{
-        border: 1,
-        p: 1,
-      }}
-    >
-      {label}
-    </Paper>
-  );
-};
-
 const RuleAgeSelector = ({
   rule,
   title,
@@ -80,311 +27,31 @@ const RuleAgeSelector = ({
   readOnly = false,
   flex = false,
 }: RuleAgeSelectorProps) => {
-  const minAge = MIN_AGE_FILTER;
-  const maxAge = MAX_AGE_FILTER;
-
-  const {
-    queryBuilderJson,
-    setQueryBuilderJson,
-    setSelectedGuidance,
-    selected,
-  } = useQueryBuilder((qb) => ({
-    queryBuilderJson: qb.queryBuilderJson,
-    setQueryBuilderJson: qb.setQueryBuilderJson,
-    setSelectedGuidance: qb.setSelectedGuidance,
-    selected: qb.selected,
-  }));
-
-  const flags = useFeatures();
-  const { constrainForBunnyV1 } = flags;
+  const { constrainForBunnyV1 } = useFeatures();
 
   const values = isRuleLeaf(rule) ? rule.ageConstraint : rule.value;
-
-  const from = values?.[0] ?? minAge;
-  const to = values?.[1] ?? maxAge;
-
-  const committedAge = useMemo<[number, number]>(() => [from, to], [from, to]);
-
-  const [draftAge, setDraftAge] = useState<[number, number] | null>(null);
-
-  const sliderValue = useMemo(() => {
-    return draftAge ?? committedAge;
-  }, [draftAge, committedAge]);
-
-  const handleCommitChange = () => {
-    const [l, r] = draftAge ?? committedAge;
-    setDraftAge(null);
-    setQueryBuilderJson(
-      updateById(queryBuilderJson, rule.id, (node) => {
-        if (isRuleLeaf(node)) {
-          return {
-            ...node,
-            ageConstraint: [
-              Math.min(l, r) > minAge ? Math.min(l, r) : null,
-              Math.max(l, r) < maxAge ? Math.max(l, r) : null,
-            ],
-          };
-        }
-        if (isAgeFilter(node)) {
-          return {
-            ...node,
-            value: [
-              Math.max(minAge, Math.min(l, r)),
-              Math.min(maxAge, Math.max(l, r)),
-            ],
-          };
-        }
-        return node;
-      }),
-    );
-  };
-
-  const handleInputChangeLeft = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setDraftAge([
-      event.target.value === "" ? 0 : Number(event.target.value),
-      sliderValue[1],
-    ]);
-  };
-
-  const handleBlurLeft = () => {
-    if (draftAge && draftAge[0] < minAge) {
-      setDraftAge([minAge, draftAge[1]]);
-    } else if (draftAge && draftAge[0] > maxAge) {
-      setDraftAge([maxAge, maxAge]);
-    } else if (draftAge && draftAge[1] < draftAge[0]) {
-      setDraftAge([draftAge[1], draftAge[0]]);
-    }
-    handleCommitChange();
-  };
-
-  const handleInputChangeRight = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setDraftAge([
-      sliderValue[0],
-      event.target.value === "" ? 0 : Number(event.target.value),
-    ]);
-  };
-
-  const handleBlurRight = () => {
-    if (draftAge && draftAge[1] < minAge) {
-      setDraftAge([minAge, minAge]);
-    } else if (draftAge && draftAge[1] > maxAge) {
-      setDraftAge([draftAge[0], maxAge]);
-    } else if (draftAge && draftAge[1] < draftAge[0]) {
-      setDraftAge([draftAge[1], draftAge[0]]);
-    }
-    handleCommitChange();
-  };
-
-  const ageConstraint: NullablePair<number> = useMemo(() => {
-    if (isRuleLeaf(rule)) {
-      return rule.ageConstraint ?? [null, null];
-    }
-
-    const l = rule.value?.[0] ?? minAge;
-    const r = rule.value?.[1] ?? maxAge;
-
-    return [l === minAge ? null : l, r === maxAge ? null : r];
-  }, [rule, minAge, maxAge]);
-
   if (!values) return null;
 
-  const key = collapsibleGuidanceKey("RuleAgeSelector", selected);
+  const from = values[0] ?? MIN_AGE_FILTER;
+  const to = values[1] ?? MAX_AGE_FILTER;
+
+  const shared = {
+    rule,
+    from,
+    to,
+    minAge: MIN_AGE_FILTER,
+    maxAge: MAX_AGE_FILTER,
+    readOnly,
+    title,
+    flex,
+    children,
+  };
 
   if (constrainForBunnyV1 && !overrideConstrainForBunny) {
-    return (
-      <HoverableDiv
-        stopPropagation={!readOnly}
-        hoverKey={`rule-age-${rule.id}`}
-        flex={flex}
-      >
-        {title && <CustomH1>{title}</CustomH1>}
-        <SingleBoundSelector<number>
-          constraint={ageConstraint}
-          constraintOperator={
-            rule.ageConstraintOperator ?? SingleSidedOperator.GREATER_THAN
-          }
-          readOnly={readOnly}
-          anyLabel="Any age"
-          onConstraintChange={(next, nextOperator) => {
-            setSelectedGuidance(key, true);
-
-            setQueryBuilderJson(
-              updateById(queryBuilderJson, rule.id, (node) => {
-                const left =
-                  next[0] == null ? null : clamp(next[0], minAge, maxAge);
-                const right =
-                  next[1] == null ? null : clamp(next[1], minAge, maxAge);
-
-                if (isRuleLeaf(node)) {
-                  return {
-                    ...node,
-                    ageConstraint: [
-                      left != null && left > minAge ? left : null,
-                      right != null && right < maxAge ? right : null,
-                    ],
-                    ageConstraintOperator: nextOperator,
-                  };
-                }
-
-                if (isAgeFilter(node)) {
-                  if (left != null) return { ...node, value: [left, maxAge] };
-                  if (right != null) return { ...node, value: [minAge, right] };
-                  return { ...node, value: [minAge, maxAge] };
-                }
-
-                return node;
-              }),
-            );
-          }}
-          renderPicker={({ value, onChange }) => (
-            <FormControlLabel
-              sx={{ m: 0 }}
-              control={
-                <TextField
-                  size="small"
-                  type="number"
-                  value={value ?? ""}
-                  slotProps={{
-                    htmlInput: { min: minAge, max: maxAge },
-                  }}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  onChange={(e) => {
-                    const raw = e.target.value;
-                    if (raw === "") return onChange(null);
-
-                    const n = Number(raw);
-                    if (Number.isNaN(n)) return;
-
-                    onChange(clamp(n, minAge, maxAge));
-                  }}
-                />
-              }
-              slotProps={{ typography: { sx: { mx: 1 } } }}
-              label="Years"
-            />
-          )}
-          renderReadOnlyLabel={() => (
-            <RuleAgeSelectorReadOnly
-              to={to}
-              from={from}
-              minAge={minAge}
-              maxAge={maxAge}
-            />
-          )}
-        />
-        {children}
-      </HoverableDiv>
-    );
+    return <RuleAgeSelectorSingleBound {...shared} />;
   }
 
-  return (
-    <HoverableDiv
-      stopPropagation={!readOnly}
-      hoverKey={`rule-age-${rule.id}`}
-      flex={flex}
-    >
-      {title && <CustomH1>{title}</CustomH1>}
-      <Stack
-        direction="row"
-        spacing={2}
-        alignItems="center"
-        justifyItems="space-between"
-        paddingY={2}
-      >
-        {readOnly ? (
-          <RuleAgeSelectorReadOnly
-            to={to}
-            from={from}
-            minAge={minAge}
-            maxAge={maxAge}
-          />
-        ) : (
-          <>
-            <TextField
-              value={sliderValue[0]}
-              size="small"
-              onChange={handleInputChangeLeft}
-              onBlur={handleBlurLeft}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleBlurLeft();
-                }
-              }}
-              slotProps={{
-                htmlInput: {
-                  step: 1,
-                  min: minAge,
-                  max: maxAge,
-                  type: "number",
-                  "aria-labelledby": "input-slider",
-                  sx: { p: 0.5 },
-                },
-              }}
-              sx={{
-                maxWidth: "7ch",
-                flexShrink: 0,
-                "& .MuiOutlinedInput-root": {
-                  borderRadius: 1,
-                },
-              }}
-            />
-            <Slider
-              value={sliderValue}
-              min={minAge}
-              max={maxAge}
-              onChange={(_e, newValue, activeThumb) => {
-                const next = newValue as number[];
-
-                const nextRange: [number, number] = uniDirectional
-                  ? activeThumb === 0
-                    ? [next[0], maxAge]
-                    : [minAge, next[1]]
-                  : [next[0], next[1]];
-
-                setDraftAge(nextRange);
-              }}
-              onChangeCommitted={handleCommitChange}
-            />
-            <TextField
-              value={sliderValue[1]}
-              size="small"
-              onChange={handleInputChangeRight}
-              onBlur={handleBlurRight}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleBlurRight();
-                }
-              }}
-              slotProps={{
-                htmlInput: {
-                  step: 1,
-                  min: minAge,
-                  max: maxAge,
-                  type: "number",
-                  "aria-labelledby": "input-slider",
-                  sx: { p: 0.5 },
-                },
-              }}
-              sx={{
-                maxWidth: "7ch",
-                flexShrink: 0,
-                "& .MuiOutlinedInput-root": {
-                  borderRadius: 1,
-                },
-              }}
-            />
-          </>
-        )}
-      </Stack>
-    </HoverableDiv>
-  );
+  return <RuleAgeSelectorSlider {...shared} uniDirectional={uniDirectional} />;
 };
 
 export default RuleAgeSelector;

--- a/src/components/RuleAgeSelector/RuleAgeSelectorReadOnly.tsx
+++ b/src/components/RuleAgeSelector/RuleAgeSelectorReadOnly.tsx
@@ -1,0 +1,38 @@
+import { Paper } from "@mui/material";
+
+const RuleAgeSelectorReadOnly = ({
+  from,
+  to,
+  minAge,
+  maxAge,
+}: {
+  from: number;
+  to: number;
+  minAge: number;
+  maxAge: number;
+}) => {
+  let label: string;
+
+  if (from === minAge && to === maxAge) {
+    label = "Any age";
+  } else if (from === minAge) {
+    label = `Age < ${to}`;
+  } else if (to === maxAge) {
+    label = `Age ≥ ${from}`;
+  } else {
+    label = `Age ${from} - ${to}`;
+  }
+
+  return (
+    <Paper
+      sx={{
+        border: 1,
+        p: 1,
+      }}
+    >
+      {label}
+    </Paper>
+  );
+};
+
+export default RuleAgeSelectorReadOnly;

--- a/src/components/RuleAgeSelector/RuleAgeSelectorSingleBound.tsx
+++ b/src/components/RuleAgeSelector/RuleAgeSelectorSingleBound.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { ReactNode, useMemo } from "react";
+import { isAgeFilter, isRuleLeaf, updateById } from "@/utils/rules";
+import {
+  AgeFilterType,
+  RuleLeafType,
+  SingleSidedOperator,
+} from "@/types/rules";
+import { CustomH1 } from "@/components/GuidanceHeaders";
+import useQueryBuilder from "@/hooks/useQueryBuilder";
+import SingleBoundSelector, {
+  NullablePair,
+} from "@/components/SingleBoundSelector";
+import { clamp } from "@/utils/numbers";
+import { collapsibleGuidanceKey } from "@/utils/queryBuilder";
+import HoverableDiv from "@/components/HoverableDiv";
+import RuleAgeSelectorReadOnly from "./RuleAgeSelectorReadOnly";
+import AgeInput from "./AgeInput";
+
+export interface RuleAgeSelectorSingleBoundProps {
+  rule: RuleLeafType | AgeFilterType;
+  from: number;
+  to: number;
+  minAge: number;
+  maxAge: number;
+  readOnly: boolean;
+  title?: string;
+  flex: boolean;
+  children?: ReactNode;
+}
+
+const RuleAgeSelectorSingleBound = ({
+  rule,
+  from,
+  to,
+  minAge,
+  maxAge,
+  readOnly,
+  title,
+  flex,
+  children,
+}: RuleAgeSelectorSingleBoundProps) => {
+  const {
+    queryBuilderJson,
+    setQueryBuilderJson,
+    setSelectedGuidance,
+    selected,
+  } = useQueryBuilder((qb) => ({
+    queryBuilderJson: qb.queryBuilderJson,
+    setQueryBuilderJson: qb.setQueryBuilderJson,
+    setSelectedGuidance: qb.setSelectedGuidance,
+    selected: qb.selected,
+  }));
+
+  const ageConstraint: NullablePair<number> = useMemo(() => {
+    if (isRuleLeaf(rule)) {
+      return rule.ageConstraint ?? [null, null];
+    }
+
+    const l = rule.value?.[0] ?? minAge;
+    const r = rule.value?.[1] ?? maxAge;
+
+    return [l === minAge ? null : l, r === maxAge ? null : r];
+  }, [rule, minAge, maxAge]);
+
+  const key = collapsibleGuidanceKey("RuleAgeSelector", selected);
+
+  const handleConstraintChange = (
+    next: NullablePair<number>,
+    nextOperator: SingleSidedOperator,
+  ) => {
+    setSelectedGuidance(key, true);
+
+    setQueryBuilderJson(
+      updateById(queryBuilderJson, rule.id, (node) => {
+        const left =
+          next[0] == null ? null : clamp(next[0], minAge, maxAge);
+        const right =
+          next[1] == null ? null : clamp(next[1], minAge, maxAge);
+
+        if (isRuleLeaf(node)) {
+          return {
+            ...node,
+            ageConstraint: [
+              left != null && left > minAge ? left : null,
+              right != null && right < maxAge ? right : null,
+            ],
+            ageConstraintOperator: nextOperator,
+          };
+        }
+
+        if (isAgeFilter(node)) {
+          if (left != null) return { ...node, value: [left, maxAge] };
+          if (right != null) return { ...node, value: [minAge, right] };
+          return { ...node, value: [minAge, maxAge] };
+        }
+
+        return node;
+      }),
+    );
+  };
+
+  return (
+    <HoverableDiv
+      stopPropagation={!readOnly}
+      hoverKey={`rule-age-${rule.id}`}
+      flex={flex}
+    >
+      {title && <CustomH1>{title}</CustomH1>}
+      <SingleBoundSelector<number>
+        constraint={ageConstraint}
+        constraintOperator={
+          rule.ageConstraintOperator ?? SingleSidedOperator.GREATER_THAN
+        }
+        readOnly={readOnly}
+        anyLabel="Any age"
+        onConstraintChange={handleConstraintChange}
+        renderPicker={({ value, onChange }) => (
+          <AgeInput
+            value={value}
+            onChange={onChange}
+            minAge={minAge}
+            maxAge={maxAge}
+          />
+        )}
+        renderReadOnlyLabel={() => (
+          <RuleAgeSelectorReadOnly
+            to={to}
+            from={from}
+            minAge={minAge}
+            maxAge={maxAge}
+          />
+        )}
+      />
+      {children}
+    </HoverableDiv>
+  );
+};
+
+export default RuleAgeSelectorSingleBound;

--- a/src/components/RuleAgeSelector/RuleAgeSelectorSlider.tsx
+++ b/src/components/RuleAgeSelector/RuleAgeSelectorSlider.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { ReactNode, useMemo, useState } from "react";
+import { Slider, Stack, TextField } from "@mui/material";
+import { isAgeFilter, isRuleLeaf, updateById } from "@/utils/rules";
+import { AgeFilterType, RuleLeafType } from "@/types/rules";
+import { CustomH1 } from "@/components/GuidanceHeaders";
+import useQueryBuilder from "@/hooks/useQueryBuilder";
+import HoverableDiv from "@/components/HoverableDiv";
+import RuleAgeSelectorReadOnly from "./RuleAgeSelectorReadOnly";
+
+export interface RuleAgeSelectorSliderProps {
+  rule: RuleLeafType | AgeFilterType;
+  from: number;
+  to: number;
+  minAge: number;
+  maxAge: number;
+  readOnly: boolean;
+  uniDirectional: boolean;
+  title?: string;
+  flex: boolean;
+  children?: ReactNode;
+}
+
+const RuleAgeSelectorSlider = ({
+  rule,
+  from,
+  to,
+  minAge,
+  maxAge,
+  readOnly,
+  uniDirectional,
+  title,
+  flex,
+  children,
+}: RuleAgeSelectorSliderProps) => {
+  const { queryBuilderJson, setQueryBuilderJson } = useQueryBuilder((qb) => ({
+    queryBuilderJson: qb.queryBuilderJson,
+    setQueryBuilderJson: qb.setQueryBuilderJson,
+  }));
+
+  const committedAge = useMemo<[number, number]>(() => [from, to], [from, to]);
+
+  const [draftAge, setDraftAge] = useState<[number, number] | null>(null);
+
+  const sliderValue = useMemo(() => {
+    return draftAge ?? committedAge;
+  }, [draftAge, committedAge]);
+
+  const handleCommitChange = () => {
+    const [l, r] = draftAge ?? committedAge;
+    setDraftAge(null);
+    setQueryBuilderJson(
+      updateById(queryBuilderJson, rule.id, (node) => {
+        if (isRuleLeaf(node)) {
+          return {
+            ...node,
+            ageConstraint: [
+              Math.min(l, r) > minAge ? Math.min(l, r) : null,
+              Math.max(l, r) < maxAge ? Math.max(l, r) : null,
+            ],
+          };
+        }
+        if (isAgeFilter(node)) {
+          return {
+            ...node,
+            value: [
+              Math.max(minAge, Math.min(l, r)),
+              Math.min(maxAge, Math.max(l, r)),
+            ],
+          };
+        }
+        return node;
+      }),
+    );
+  };
+
+  const handleInputChangeLeft = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setDraftAge([
+      event.target.value === "" ? 0 : Number(event.target.value),
+      sliderValue[1],
+    ]);
+  };
+
+  const handleBlurLeft = () => {
+    if (draftAge && draftAge[0] < minAge) {
+      setDraftAge([minAge, draftAge[1]]);
+    } else if (draftAge && draftAge[0] > maxAge) {
+      setDraftAge([maxAge, maxAge]);
+    } else if (draftAge && draftAge[1] < draftAge[0]) {
+      setDraftAge([draftAge[1], draftAge[0]]);
+    }
+    handleCommitChange();
+  };
+
+  const handleInputChangeRight = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setDraftAge([
+      sliderValue[0],
+      event.target.value === "" ? 0 : Number(event.target.value),
+    ]);
+  };
+
+  const handleBlurRight = () => {
+    if (draftAge && draftAge[1] < minAge) {
+      setDraftAge([minAge, minAge]);
+    } else if (draftAge && draftAge[1] > maxAge) {
+      setDraftAge([draftAge[0], maxAge]);
+    } else if (draftAge && draftAge[1] < draftAge[0]) {
+      setDraftAge([draftAge[1], draftAge[0]]);
+    }
+    handleCommitChange();
+  };
+
+  const handleSliderChange = (
+    _e: Event,
+    newValue: number | number[],
+    activeThumb: number,
+  ) => {
+    const next = newValue as number[];
+
+    const nextRange: [number, number] = uniDirectional
+      ? activeThumb === 0
+        ? [next[0], maxAge]
+        : [minAge, next[1]]
+      : [next[0], next[1]];
+
+    setDraftAge(nextRange);
+  };
+
+  return (
+    <HoverableDiv
+      stopPropagation={!readOnly}
+      hoverKey={`rule-age-${rule.id}`}
+      flex={flex}
+    >
+      {title && <CustomH1>{title}</CustomH1>}
+      <Stack
+        direction="row"
+        spacing={2}
+        alignItems="center"
+        justifyItems="space-between"
+        paddingY={2}
+      >
+        {readOnly ? (
+          <RuleAgeSelectorReadOnly
+            to={to}
+            from={from}
+            minAge={minAge}
+            maxAge={maxAge}
+          />
+        ) : (
+          <>
+            <TextField
+              value={sliderValue[0]}
+              size="small"
+              onChange={handleInputChangeLeft}
+              onBlur={handleBlurLeft}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  handleBlurLeft();
+                }
+              }}
+              slotProps={{
+                htmlInput: {
+                  step: 1,
+                  min: minAge,
+                  max: maxAge,
+                  type: "number",
+                  "aria-labelledby": "input-slider",
+                  sx: { p: 0.5 },
+                },
+              }}
+              sx={{
+                maxWidth: "7ch",
+                flexShrink: 0,
+                "& .MuiOutlinedInput-root": {
+                  borderRadius: 1,
+                },
+              }}
+            />
+            <Slider
+              value={sliderValue}
+              min={minAge}
+              max={maxAge}
+              onChange={handleSliderChange}
+              onChangeCommitted={handleCommitChange}
+            />
+            <TextField
+              value={sliderValue[1]}
+              size="small"
+              onChange={handleInputChangeRight}
+              onBlur={handleBlurRight}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  handleBlurRight();
+                }
+              }}
+              slotProps={{
+                htmlInput: {
+                  step: 1,
+                  min: minAge,
+                  max: maxAge,
+                  type: "number",
+                  "aria-labelledby": "input-slider",
+                  sx: { p: 0.5 },
+                },
+              }}
+              sx={{
+                maxWidth: "7ch",
+                flexShrink: 0,
+                "& .MuiOutlinedInput-root": {
+                  borderRadius: 1,
+                },
+              }}
+            />
+          </>
+        )}
+      </Stack>
+      {children}
+    </HoverableDiv>
+  );
+};
+
+export default RuleAgeSelectorSlider;

--- a/src/components/RuleAgeSelector/__tests__/RuleAgeSelector.test.tsx
+++ b/src/components/RuleAgeSelector/__tests__/RuleAgeSelector.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import RuleAgeSelector, { RuleAgeSelectorProps } from "../RuleAgeSelector";
+import MockCohortDiscoveryServiceStore from "@/store/MockCohortDiscoveryServiceStore";
+import { createAgeFilter, createRuleGroup } from "@/utils/rules";
+import { MAX_AGE_FILTER } from "@/config/rules";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const setQueryBuilderJson = jest.fn();
+
+const renderComponent = (
+  props: Partial<RuleAgeSelectorProps>,
+  flagOn: boolean,
+) =>
+  render(
+    <MockCohortDiscoveryServiceStore
+      overrides={{
+        featureFlags: { flags: { "constrain-for-bunny-v1": flagOn } },
+        queryBuilder: {
+          queryBuilderJson: createRuleGroup(),
+          setQueryBuilderJson,
+          setSelectedGuidance: jest.fn(),
+          selected: {},
+        },
+      }}
+    >
+      <RuleAgeSelector rule={createAgeFilter()} {...props} />
+    </MockCohortDiscoveryServiceStore>,
+  );
+
+describe("RuleAgeSelector", () => {
+  describe("when constrainForBunnyV1 is off", () => {
+    it("renders the slider in edit mode", () => {
+      renderComponent({ readOnly: false }, false);
+      expect(screen.getAllByRole("slider")).toHaveLength(2);
+      expect(screen.queryByText("Years")).not.toBeInTheDocument();
+    });
+
+    it("renders the read-only label when readOnly is true", () => {
+      renderComponent({ readOnly: true }, false);
+      expect(screen.getByText("Any age")).toBeInTheDocument();
+      expect(screen.queryAllByRole("slider")).toHaveLength(0);
+    });
+  });
+
+  describe("when constrainForBunnyV1 is on", () => {
+    it("renders the SingleBound path in edit mode", () => {
+      // Pass a rule with a non-default lower bound so SingleBoundSelector
+      // renders the constraint input rather than staying in "Any age" mode.
+      const ruleWithConstraint = { ...createAgeFilter(), value: [18, MAX_AGE_FILTER] as [number, number] };
+      renderComponent({ readOnly: false, rule: ruleWithConstraint }, true);
+      expect(screen.getByText("Years")).toBeInTheDocument();
+      expect(screen.queryAllByRole("slider")).toHaveLength(0);
+    });
+
+    it("renders the read-only label when readOnly is true", () => {
+      renderComponent({ readOnly: true }, true);
+      expect(screen.getByText("Any age")).toBeInTheDocument();
+      expect(screen.queryByText("Years")).not.toBeInTheDocument();
+      expect(screen.queryAllByRole("slider")).toHaveLength(0);
+    });
+
+    it("falls back to the slider when overrideConstrainForBunny is true", () => {
+      renderComponent({ readOnly: false, overrideConstrainForBunny: true }, true);
+      expect(screen.getAllByRole("slider")).toHaveLength(2);
+      expect(screen.queryByText("Years")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/RuleAgeSelector/__tests__/RuleAgeSelectorReadOnly.test.tsx
+++ b/src/components/RuleAgeSelector/__tests__/RuleAgeSelectorReadOnly.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import RuleAgeSelectorReadOnly from "../RuleAgeSelectorReadOnly";
+import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
+
+describe("RuleAgeSelectorReadOnly", () => {
+  it('displays "Any age" when range covers the full span', () => {
+    render(
+      <RuleAgeSelectorReadOnly
+        from={MIN_AGE_FILTER}
+        to={MAX_AGE_FILTER}
+        minAge={MIN_AGE_FILTER}
+        maxAge={MAX_AGE_FILTER}
+      />,
+    );
+    expect(screen.getByText("Any age")).toBeInTheDocument();
+  });
+
+  it('displays "Age < X" when lower bound is at minimum', () => {
+    render(
+      <RuleAgeSelectorReadOnly
+        from={MIN_AGE_FILTER}
+        to={65}
+        minAge={MIN_AGE_FILTER}
+        maxAge={MAX_AGE_FILTER}
+      />,
+    );
+    expect(screen.getByText("Age < 65")).toBeInTheDocument();
+  });
+
+  it('displays "Age ≥ X" when upper bound is at maximum', () => {
+    render(
+      <RuleAgeSelectorReadOnly
+        from={18}
+        to={MAX_AGE_FILTER}
+        minAge={MIN_AGE_FILTER}
+        maxAge={MAX_AGE_FILTER}
+      />,
+    );
+    expect(screen.getByText("Age ≥ 18")).toBeInTheDocument();
+  });
+
+  it("displays a range label for a custom age range", () => {
+    render(
+      <RuleAgeSelectorReadOnly
+        from={18}
+        to={65}
+        minAge={MIN_AGE_FILTER}
+        maxAge={MAX_AGE_FILTER}
+      />,
+    );
+    expect(screen.getByText("Age 18 - 65")).toBeInTheDocument();
+  });
+});

--- a/src/components/RuleAgeSelector/index.ts
+++ b/src/components/RuleAgeSelector/index.ts
@@ -1,3 +1,4 @@
 import RuleAgeSelector from "./RuleAgeSelector";
 
+export { default as RuleAgeSelectorReadOnly } from "./RuleAgeSelectorReadOnly";
 export default RuleAgeSelector;

--- a/src/modules/RuleAgeFilter/RuleAgeFilter.tsx
+++ b/src/modules/RuleAgeFilter/RuleAgeFilter.tsx
@@ -1,11 +1,12 @@
 import { Box } from "@mui/material";
 import { AgeFilterType } from "@/types/rules";
 import { DragType } from "@/types/dnd";
+import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
 
 import RuleWrapper from "../RuleWrapper";
 import { RuleWrapperProps } from "../RuleWrapper/RuleWrapper";
 import useNodeActions from "@/hooks/useNodeActions";
-import RuleAgeSelector from "@/components/RuleAgeSelector";
+import { RuleAgeSelectorReadOnly } from "@/components/RuleAgeSelector";
 import DomainChip from "@/components/DomainChip/DomainChip";
 
 export interface RuleProps extends Omit<
@@ -19,6 +20,9 @@ export interface RuleProps extends Omit<
 const RuleAgeFilter = ({ rule, groupId, ...rest }: RuleProps) => {
   const { actions } = useNodeActions(rule);
 
+  const from = rule.value?.[0] ?? MIN_AGE_FILTER;
+  const to = rule.value?.[1] ?? MAX_AGE_FILTER;
+
   return (
     <RuleWrapper
       node={rule}
@@ -27,8 +31,13 @@ const RuleAgeFilter = ({ rule, groupId, ...rest }: RuleProps) => {
       sortable={true}
       headerExtra={<DomainChip label="Age" />}
       render={() => (
-        <Box sx={{ width: "fit-content" }}>
-          <RuleAgeSelector rule={rule} readOnly overrideConstrainForBunny />
+        <Box sx={{ width: "fit-content", my: 2 }}>
+          <RuleAgeSelectorReadOnly
+            from={from}
+            to={to}
+            minAge={MIN_AGE_FILTER}
+            maxAge={MAX_AGE_FILTER}
+          />
         </Box>
       )}
       actions={actions}


### PR DESCRIPTION
> **AI-assisted:** This PR was prepared with the help of Claude (Anthropic). All changes were reviewed by the author.

## Summary

Decomposed the monolithic `RuleAgeSelector` component into focused, single-responsibility files. The 420-line file previously bundled two completely unrelated rendering paths (SingleBoundSelector / Bunny path and legacy slider path) alongside sub-components and all their state/handlers. Each concern now lives in its own file. `RuleAgeFilter` (the rule board tile) was also updated to bypass the full `RuleAgeSelector` and render the read-only label directly, avoiding loading edit-mode hooks and state it never uses.

## Jira

https://hdruk.atlassian.net/browse/DP-870

## PR Type

- [ ] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [x] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

`refactor(DP-870): decompose RuleAgeSelector into focused sub-components`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## What changed

`src/components/RuleAgeSelector/` now contains:

| File | Role |
|------|------|
| `RuleAgeSelector.tsx` | Thin dispatcher (~55 lines): derives `from`/`to`, checks feature flag, renders sub-component |
| `RuleAgeSelectorSingleBound.tsx` | Bunny/`constrainForBunnyV1` path — `ageConstraint` memo, `handleConstraintChange` named callback |
| `RuleAgeSelectorSlider.tsx` | Legacy slider path — all slider state and handlers, `handleSliderChange` named callback |
| `RuleAgeSelectorReadOnly.tsx` | Display-only label (`"Any age"`, `"Age ≥ X"`, etc.) |
| `AgeInput.tsx` | Number input helper used by the SingleBound path |

`src/modules/RuleAgeFilter/RuleAgeFilter.tsx` now imports `RuleAgeSelectorReadOnly` directly (it always rendered read-only, so pulling in the full interactive component was wasteful).

Key code quality improvements:
- The large inline `onConstraintChange` arrow function is now the named `handleConstraintChange`
- The inline `Slider onChange` arrow is now the named `handleSliderChange`

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [x] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [x] Side-effectful endpoints are not cached unintentionally
- [x] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

No visual change — this is a pure refactor. All existing rendering paths are preserved exactly.

## Risk and Rollback

- Risk level: low
- Main risk areas:
  - `RuleAgeSelector` consumers (`RuleWrapper`, `Guidance`) — props interface is unchanged, behaviour is identical
  - `RuleAgeFilter` — now renders `RuleAgeSelectorReadOnly` directly; verified equivalent output
- Rollback plan:
  - Revert PR — no data or API changes, safe to revert at any time

## Notes for Reviewers

The only behavioural change is in `RuleAgeFilter`: previously it passed `readOnly overrideConstrainForBunny` through the full `RuleAgeSelector` (loading `useQueryBuilder`, `useFeatures`, slider state etc.), now it renders `RuleAgeSelectorReadOnly` directly with `from`/`to` derived from `rule.value`. The rendered output is identical.

Worth checking: the `{children}` prop in `RuleAgeSelectorSlider` is now rendered after the `Stack` (inside `HoverableDiv`) — in the original code the legacy slider branch had no `{children}` at all. Since no caller passes children to this path today, this is harmless.
