### PR TITLE
fix(DP-897): infer existing group operator when dragging out

### DIFF
--- a/src/modules/Rule/RuleSearch.tsx
+++ b/src/modules/Rule/RuleSearch.tsx
@@ -26,7 +26,10 @@ const RuleSearch = ({ onConfirm, isSelected, onSelect }: RuleSearchProps) => {
   });
 
   const conceptsMap = useWatch({ control, name: "concepts", defaultValue: {} });
-  const selectedConcepts = useMemo(() => Object.values(conceptsMap), [conceptsMap]);
+  const selectedConcepts = useMemo(
+    () => Object.values(conceptsMap),
+    [conceptsMap],
+  );
 
   const handleOnToggle = useCallback(
     (concept: Concept, toggled: boolean) => {
@@ -126,7 +129,7 @@ const RuleSearch = ({ onConfirm, isSelected, onSelect }: RuleSearchProps) => {
   const toggleRow = hasOptions ? (
     <Stack
       direction="row"
-      justifyContent="space-between"
+      justifyContent="flex-start"
       alignItems="center"
       py={0.75}
     >
@@ -147,7 +150,13 @@ const RuleSearch = ({ onConfirm, isSelected, onSelect }: RuleSearchProps) => {
   ) : null;
 
   return (
-    <Box data-testid="rule-search-container" onClick={(e) => { e.stopPropagation(); onSelect?.(); }}>
+    <Box
+      data-testid="rule-search-container"
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect?.();
+      }}
+    >
       <SearchConcepts
         multiple={isMultiSelect}
         hideSelectAll

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -710,10 +710,12 @@ export const removeConceptFromSource =
     return { ...node, rule: { ...node.rule, concept: remaining } };
   };
 
-export const normaliseOps = (group: RuleNodeType): RuleNodeType =>
-  isRuleGroup(group)
-    ? { ...group, rules: insertMissingOperators(group.rules) }
-    : group;
+export const normaliseOps = (group: RuleNodeType): RuleNodeType => {
+  if (!isRuleGroup(group)) return group;
+  const existingOp = group.rules.find(isOperator);
+  const combinator = existingOp ? existingOp.combinator : CombinatorType.OR;
+  return { ...group, rules: insertMissingOperators(group.rules, combinator) };
+};
 
 export const mergeConceptIntoRule =
   (concept: Concept) =>


### PR DESCRIPTION
## Summary

Two quick fixes
1) align text to the left for enable multi/single- select
2) when concepts are dragged out of rules, the operator needs to be inferred 

## Jira

https://hdruk.atlassian.net/browse/DP-897

https://hdruk.atlassian.net/browse/DP-898

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<img width="371" height="251" alt="image" src="https://github.com/user-attachments/assets/e6764b3f-172f-49a6-b232-78d9cd1c7051" />


## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
