### PR TITLE
feat(DP-903): term directory page foundation & browse

### DIFF
--- a/cypress/e2e/term-directory/term-directory.cy.ts
+++ b/cypress/e2e/term-directory/term-directory.cy.ts
@@ -1,0 +1,22 @@
+describe("Term Directory", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit("/term-directory");
+  });
+
+  it("renders the page heading", () => {
+    cy.contains("Term Directory").should("be.visible");
+  });
+
+  it("shows the correct table columns", () => {
+    cy.contains("OMOP ID").should("be.visible");
+    cy.contains("Term Name").should("be.visible");
+    cy.contains("Count").should("be.visible");
+    cy.contains("Associated Collections").should("be.visible");
+  });
+
+  it("renders rows from the fixture", () => {
+    cy.contains("Type 2 diabetes mellitus").should("be.visible");
+    cy.contains("Myocardial infarction").should("be.visible");
+  });
+});

--- a/cypress/fixtures/term-directory.json
+++ b/cypress/fixtures/term-directory.json
@@ -1,0 +1,27 @@
+{
+  "message": "OK",
+  "data": {
+    "data": [
+      {
+        "concept_id": 201826,
+        "concept_name": "Type 2 diabetes mellitus",
+        "domain_id": "Condition",
+        "count": 420,
+        "ncollections": 2
+      },
+      {
+        "concept_id": 4329847,
+        "concept_name": "Myocardial infarction",
+        "domain_id": "Condition",
+        "count": 50,
+        "ncollections": 1
+      }
+    ],
+    "current_page": 1,
+    "last_page": 1,
+    "per_page": 25,
+    "total": 2,
+    "from": 1,
+    "to": 2
+  }
+}

--- a/cypress/support/mock-server.js
+++ b/cypress/support/mock-server.js
@@ -474,6 +474,13 @@ async function handle(req, res) {
   }
 
   // -------------------------------------------------------------------------
+  // Term Directory
+  // -------------------------------------------------------------------------
+  if (method === "GET" && pathname === "/api/v1/term-directory") {
+    return json(res, 200, fixture("term-directory"));
+  }
+
+  // -------------------------------------------------------------------------
   // Fallthrough – return 404 so tests fail loudly on missing routes
   // -------------------------------------------------------------------------
   console.warn(`[mock-server] Unhandled ${method} ${pathname}`);

--- a/src/actions/termDirectory/__mocks__/getTermDirectory.ts
+++ b/src/actions/termDirectory/__mocks__/getTermDirectory.ts
@@ -1,0 +1,34 @@
+import { TermDirectoryEntry, ApiResponse, Paginated } from "@/types/api";
+import { paginateData } from "@/utils/mock";
+
+export const getMockTermDirectoryEntry = (
+  rest?: Partial<TermDirectoryEntry>,
+): TermDirectoryEntry => ({
+  concept_id: 201826,
+  concept_name: "Type 2 diabetes mellitus",
+  domain_id: "Condition",
+  count: 1234,
+  ncollections: 2,
+  ...rest,
+});
+
+export const mockTermDirectoryEntries: TermDirectoryEntry[] = [
+  getMockTermDirectoryEntry(),
+  getMockTermDirectoryEntry({
+    concept_id: 4329847,
+    concept_name: "Myocardial infarction",
+    count: 50,
+    ncollections: 1,
+  }),
+];
+
+const getTermDirectory = async (): Promise<
+  ApiResponse<Paginated<TermDirectoryEntry>>
+> => {
+  return {
+    message: "success",
+    data: paginateData({ data: mockTermDirectoryEntries }),
+  };
+};
+
+export default getTermDirectory;

--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { apiGet } from "@/lib/apiClient";
+import { API_ROUTES } from "@/lib/apiRoutes";
+import { TermDirectoryEntry, ApiResponse, Paginated } from "@/types/api";
+import { DEFAULT_PER_PAGE } from "@/config/defaults";
+import { getTagTermDirectory } from "@/config/tags";
+
+const getTermDirectory = async (
+  page = 1,
+  per_page = DEFAULT_PER_PAGE,
+): Promise<ApiResponse<Paginated<TermDirectoryEntry>>> => {
+  const params = new URLSearchParams({
+    page: String(page),
+    per_page: String(per_page),
+  });
+
+  const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({
+    url: API_ROUTES.termDirectory,
+    params,
+    tags: getTagTermDirectory(),
+  });
+
+  const rows = result.data.data.map((entry) => ({
+    ...entry,
+    id: entry.concept_id,
+  }));
+
+  return {
+    ...result,
+    data: {
+      ...result.data,
+      data: rows,
+    },
+  };
+};
+
+export default getTermDirectory;

--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -26,18 +26,7 @@ const getTermDirectory = async (
     tags: [getTagTermDirectory(userId)],
   });
 
-  const rows = result.data.data.map((entry) => ({
-    ...entry,
-    id: entry.concept_id,
-  }));
-
-  return {
-    ...result,
-    data: {
-      ...result.data,
-      data: rows,
-    },
-  };
+  return result;
 };
 
 export default getTermDirectory;

--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { getTokenUser } from "@/lib/auth";
 import { apiGet } from "@/lib/apiClient";
 import { API_ROUTES } from "@/lib/apiRoutes";
 import { TermDirectoryEntry, ApiResponse, Paginated } from "@/types/api";
@@ -10,6 +11,10 @@ const getTermDirectory = async (
   page = 1,
   per_page = DEFAULT_PER_PAGE,
 ): Promise<ApiResponse<Paginated<TermDirectoryEntry>>> => {
+  const {
+    user: { id: userId },
+  } = await getTokenUser();
+
   const params = new URLSearchParams({
     page: String(page),
     per_page: String(per_page),
@@ -18,7 +23,7 @@ const getTermDirectory = async (
   const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({
     url: API_ROUTES.termDirectory,
     params,
-    tags: getTagTermDirectory(),
+    tags: [getTagTermDirectory(userId)],
   });
 
   const rows = result.data.data.map((entry) => ({

--- a/src/app/(protected)/term-directory/page.tsx
+++ b/src/app/(protected)/term-directory/page.tsx
@@ -1,0 +1,31 @@
+import { Paper, Skeleton } from "@mui/material";
+import { Suspense } from "react";
+import Title from "@/components/Title";
+import TermDirectory from "@/modules/TermDirectory";
+import getTermDirectory from "@/actions/termDirectory/getTermDirectory";
+
+interface PageProps {
+  searchParams: Promise<{ page?: string; per_page?: string }>;
+}
+
+const TermDirectoryPageContent = async ({ searchParams }: PageProps) => {
+  const params = await searchParams;
+  const page = params?.page ? parseInt(params.page) : undefined;
+  const perPage = params?.per_page ? parseInt(params.per_page) : undefined;
+  const result = await getTermDirectory(page, perPage);
+
+  return (
+    <Paper sx={{ p: 2, gap: 2, display: "flex", flexDirection: "column" }}>
+      <Title title="Term Directory" subTitle={result.data.total} />
+      <TermDirectory entries={result.data} />
+    </Paper>
+  );
+};
+
+const TermDirectoryPage = ({ searchParams }: PageProps) => (
+  <Suspense fallback={<Skeleton variant="rectangular" height={400} />}>
+    <TermDirectoryPageContent searchParams={searchParams} />
+  </Suspense>
+);
+
+export default TermDirectoryPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,10 +47,7 @@ export default async function RootLayout({
                   sx={{
                     display: "flex",
                     flexDirection: "column",
-                    // Double check this looks good on all pages when changed from 120vh to 100vh
-                    // Original was "120vh" to account for the footer
-                    // but this was causing a scroll bar to appear on some pages
-                    height: "100vh",
+                    height: "120vh",
                   }}
                 >
                   {!standalone && <SupportPopOut />}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,7 +47,10 @@ export default async function RootLayout({
                   sx={{
                     display: "flex",
                     flexDirection: "column",
-                    height: "120vh",
+                    // Double check this looks good on all pages when changed from 120vh to 100vh
+                    // Original was "120vh" to account for the footer
+                    // but this was causing a scroll bar to appear on some pages
+                    height: "100vh",
                   }}
                 >
                   {!standalone && <SupportPopOut />}

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -50,4 +50,5 @@ export const routes = {
   teamCollections: (pid: string) => teamPath(pid, "collections"),
   config: adminPath("configuration"),
   adminRegression: adminPath("regression"),
+  termDirectory: "/term-directory",
 };

--- a/src/config/tags.ts
+++ b/src/config/tags.ts
@@ -58,4 +58,5 @@ export const getTagRegressionTest = (pid: string) => `regression-test-${pid}`;
 export const TAG_USERS = "users";
 export const TAG_ADMIN_USERS = "admin-users";
 
-export const getTagTermDirectory = () => ["term-directory"];
+export const getTagTermDirectory = (userId: string | number) =>
+  `term-directory-${userId}`;

--- a/src/config/tags.ts
+++ b/src/config/tags.ts
@@ -53,8 +53,9 @@ export const getTagsQuery = (pid: string) => ["query", getTagQuery(pid)];
 
 export const TAG_REGRESSION_TESTS = "regression-tests";
 export const TAG_REGRESSION_TASK = "regression-task";
-export const getTagRegressionTest = (pid: string) =>
-  `regression-test-${pid}`;
+export const getTagRegressionTest = (pid: string) => `regression-test-${pid}`;
 
 export const TAG_USERS = "users";
 export const TAG_ADMIN_USERS = "admin-users";
+
+export const getTagTermDirectory = () => ["term-directory"];

--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -26,7 +26,7 @@ interface UsePaginatedTableOptions<TData extends MRT_RowData> extends Partial<
   perPageParam?: string;
 }
 
-export function usePaginatedTable<TData extends { id: number; pid?: string }>({
+export function usePaginatedTable<TData extends { id?: number; pid?: string }>({
   columns,
   data,
   rowCount,

--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -94,7 +94,7 @@ export function usePaginatedTable<TData extends MRT_RowData>({
     perPageParam,
   ]);
 
-  const firstRowId = getRowId(data?.[0]);
+  const firstRowId = data?.length ? getRowId(data[0]) : undefined;
   const expanded = useMemo(() => {
     return firstRowId && expandFirstRow ? { [firstRowId]: true } : {};
   }, [firstRowId, expandFirstRow]);

--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -94,7 +94,7 @@ export function usePaginatedTable<TData extends MRT_RowData>({
     perPageParam,
   ]);
 
-  const firstRowId = data?.length ? getRowId(data?.[0]) : undefined;
+  const firstRowId = getRowId(data?.[0]);
   const expanded = useMemo(() => {
     return firstRowId && expandFirstRow ? { [firstRowId]: true } : {};
   }, [firstRowId, expandFirstRow]);

--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -26,7 +26,7 @@ interface UsePaginatedTableOptions<TData extends MRT_RowData> extends Partial<
   perPageParam?: string;
 }
 
-export function usePaginatedTable<TData extends { id?: number; pid?: string }>({
+export function usePaginatedTable<TData extends MRT_RowData>({
   columns,
   data,
   rowCount,

--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -94,7 +94,7 @@ export function usePaginatedTable<TData extends MRT_RowData>({
     perPageParam,
   ]);
 
-  const firstRowId = getRowId(data?.[0]);
+  const firstRowId = data?.length ? getRowId(data?.[0]) : undefined;
   const expanded = useMemo(() => {
     return firstRowId && expandFirstRow ? { [firstRowId]: true } : {};
   }, [firstRowId, expandFirstRow]);

--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -94,7 +94,7 @@ export function usePaginatedTable<TData extends MRT_RowData>({
     perPageParam,
   ]);
 
-  const firstRowId = data?.length ? getRowId(data[0]) : undefined;
+  const firstRowId = getRowId(data?.[0]);
   const expanded = useMemo(() => {
     return firstRowId && expandFirstRow ? { [firstRowId]: true } : {};
   }, [firstRowId, expandFirstRow]);

--- a/src/lib/apiRoutes.ts
+++ b/src/lib/apiRoutes.ts
@@ -56,6 +56,7 @@ export const API_ROUTES = {
   user: (id: number) => `${API_URL}/users/${id}`,
   featureFlags: `${API_URL}/features`,
   feature: (name: string) => `${API_URL}/features/${name}`,
+  termDirectory: `${API_URL}/term-directory`,
 };
 
 export const GATEWAY_ROUTES = {

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom";
+import { render, screen, within } from "@testing-library/react";
+import TermDirectory from "./TermDirectory";
+import { TermDirectoryEntry } from "@/types/api";
+import { paginateData } from "@/utils/mock";
+
+const mockEntries: TermDirectoryEntry[] = [
+  {
+    concept_id: 201826,
+    concept_name: "Type 2 diabetes mellitus",
+    domain_id: "Condition",
+    count: 1234,
+    ncollections: 2,
+  },
+  {
+    concept_id: 4329847,
+    concept_name: "Myocardial infarction",
+    domain_id: "Condition",
+    count: 50,
+    ncollections: 1,
+  },
+];
+
+describe("TermDirectory", () => {
+  it("renders the correct column headers", () => {
+    render(<TermDirectory entries={paginateData({ data: mockEntries })} />);
+
+    const columns = ["OMOP ID", "Term Name", "Count", "Associated Collections"];
+    for (const column of columns) {
+      expect(
+        screen.getByRole("columnheader", { name: new RegExp(column) }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders a row per entry with its OMOP id, name and collection count", () => {
+    render(<TermDirectory entries={paginateData({ data: mockEntries })} />);
+
+    const firstRow = screen.getByRole("row", {
+      name: /Type 2 diabetes mellitus/i,
+    });
+    expect(within(firstRow).getByText("201826")).toBeInTheDocument();
+    expect(within(firstRow).getByText("2")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("row", { name: /Myocardial infarction/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("formats the count with thousands separators for readability", () => {
+    render(<TermDirectory entries={paginateData({ data: mockEntries })} />);
+
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+  });
+
+  it("shows an empty message when no terms are returned", () => {
+    render(<TermDirectory entries={paginateData({ data: [] })} />);
+
+    expect(screen.getByText("No terms found.")).toBeInTheDocument();
+  });
+});

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -42,12 +42,14 @@ describe("TermDirectory", () => {
     expect(within(firstRow).getByText("201826")).toBeInTheDocument();
     expect(within(firstRow).getByText("2")).toBeInTheDocument();
 
-    expect(
-      screen.getByRole("row", { name: /Myocardial infarction/i }),
-    ).toBeInTheDocument();
+    const secondRow = screen.getByRole("row", {
+      name: /Myocardial infarction/i,
+    });
+    expect(within(secondRow).getByText("4329847")).toBeInTheDocument();
+    expect(within(secondRow).getByText("1")).toBeInTheDocument();
   });
 
-  it("formats the count with thousands separators for readability", () => {
+  it("renders the count, formatted with thousands separators for readability", () => {
     render(<TermDirectory entries={paginateData({ data: mockEntries })} />);
 
     expect(screen.getByText("1,234")).toBeInTheDocument();

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -1,29 +1,12 @@
 import "@testing-library/jest-dom";
 import { render, screen, within } from "@testing-library/react";
 import TermDirectory from "./TermDirectory";
-import { TermDirectoryEntry } from "@/types/api";
+import { mockTermDirectoryEntries } from "@/actions/termDirectory/__mocks__/getTermDirectory";
 import { paginateData } from "@/utils/mock";
-
-const mockEntries: TermDirectoryEntry[] = [
-  {
-    concept_id: 201826,
-    concept_name: "Type 2 diabetes mellitus",
-    domain_id: "Condition",
-    count: 1234,
-    ncollections: 2,
-  },
-  {
-    concept_id: 4329847,
-    concept_name: "Myocardial infarction",
-    domain_id: "Condition",
-    count: 50,
-    ncollections: 1,
-  },
-];
 
 describe("TermDirectory", () => {
   it("renders the correct column headers", () => {
-    render(<TermDirectory entries={paginateData({ data: mockEntries })} />);
+    render(<TermDirectory entries={paginateData({ data: mockTermDirectoryEntries })} />);
 
     const columns = ["OMOP ID", "Term Name", "Count", "Associated Collections"];
     for (const column of columns) {
@@ -34,7 +17,7 @@ describe("TermDirectory", () => {
   });
 
   it("renders a row per entry with its OMOP id, name and collection count", () => {
-    render(<TermDirectory entries={paginateData({ data: mockEntries })} />);
+    render(<TermDirectory entries={paginateData({ data: mockTermDirectoryEntries })} />);
 
     const firstRow = screen.getByRole("row", {
       name: /Type 2 diabetes mellitus/i,
@@ -50,7 +33,7 @@ describe("TermDirectory", () => {
   });
 
   it("renders the count, formatted with thousands separators for readability", () => {
-    render(<TermDirectory entries={paginateData({ data: mockEntries })} />);
+    render(<TermDirectory entries={paginateData({ data: mockTermDirectoryEntries })} />);
 
     expect(screen.getByText("1,234")).toBeInTheDocument();
   });

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -49,7 +49,7 @@ const TermDirectory = ({
     data: entries.data,
     rowCount: entries.total,
     perPageDefault: DEFAULT_PER_PAGE,
-    getRowId: (row) => String(row.concept_id),
+    getRowId: (row) => String(row?.concept_id),
     enableStickyHeader: true,
   });
 

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -51,7 +51,6 @@ const TermDirectory = ({
     perPageDefault: DEFAULT_PER_PAGE,
     getRowId: (row) => String(row.concept_id),
     enableStickyHeader: true,
-    muiTableContainerProps: { sx: { maxHeight: "calc(100vh - 300px)" } },
   });
 
   return <Table table={table} emptyMessage="No terms found." />;

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { type MRT_ColumnDef } from "material-react-table";
+import { useMemo } from "react";
+import { TermDirectoryEntry, Paginated } from "@/types/api";
+import { usePaginatedTable } from "@/hooks/usePaginatedTable";
+import Table from "@/components/Table";
+import { formatNumber } from "@/utils/numbers";
+import { DEFAULT_PER_PAGE } from "@/config/defaults";
+
+const TermDirectory = ({
+  entries,
+}: {
+  entries: Paginated<TermDirectoryEntry>;
+}) => {
+  const columns = useMemo<MRT_ColumnDef<TermDirectoryEntry>[]>(
+    () => [
+      {
+        id: "concept_id",
+        header: "OMOP ID",
+        accessorFn: (row) => row.concept_id,
+        size: 120,
+      },
+      {
+        id: "concept_name",
+        header: "Term Name",
+        accessorFn: (row) => row.concept_name,
+        size: 400,
+      },
+      {
+        id: "count",
+        header: "Count",
+        accessorFn: (row) => row.count,
+        Cell: ({ cell }) => formatNumber(cell.getValue<number>()),
+        size: 100,
+      },
+      {
+        id: "ncollections",
+        header: "Associated Collections",
+        accessorFn: (row) => row.ncollections,
+        size: 160,
+      },
+    ],
+    [],
+  );
+
+  const table = usePaginatedTable<TermDirectoryEntry>({
+    columns,
+    data: entries.data,
+    rowCount: entries.total,
+    perPageDefault: DEFAULT_PER_PAGE,
+    getRowId: (row) => String(row.concept_id),
+    enableStickyHeader: true,
+    muiTableContainerProps: { sx: { maxHeight: "calc(100vh - 300px)" } },
+  });
+
+  return <Table table={table} emptyMessage="No terms found." />;
+};
+
+export default TermDirectory;

--- a/src/modules/TermDirectory/index.ts
+++ b/src/modules/TermDirectory/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TermDirectory";

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -234,7 +234,6 @@ export interface TermDirectoryEntry {
   domain_id: string;
   count: number;
   ncollections: number;
-  id: number; // alias of concept_id, required by usePaginatedTable
 }
 
 export interface TaskRun {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -228,6 +228,15 @@ export interface CodeStat extends Code {
   collections_pct: number;
 }
 
+export interface TermDirectoryEntry {
+  concept_id: number;
+  concept_name: string;
+  domain_id: string;
+  count: number;
+  ncollections: number;
+  id: number; // alias of concept_id, required by usePaginatedTable
+}
+
 export interface TaskRun {
   duration_ms: number;
   error_class: string;


### PR DESCRIPTION
## Summary

Adds the `/term-directory` page to the frontend that allows for browsing a paginated table of every OMOP concept scoped to the user's available collections. It's built on the `usePaginatedTable()` hook that existed in the project. The backend endpoint was already in place from DP-910.

Search, filter, navbar link and other features will be added in the following tickets.

## Jira

https://hdruk.atlassian.net/browse/DP-903

## PR Type

- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [x] UI changes
- [x] API integration changes (`src/actions/*`)
- [x] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [x] State management changes (hooks/store)
- [x] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<img width="1602" height="540" alt="image" src="https://github.com/user-attachments/assets/9e55a3f8-8601-40cd-bebb-0eec7b485d76" />