### PR TITLE
feat(DP-929): Update for query parser to send collections

### DIFF
--- a/src/actions/query/parseQuery.ts
+++ b/src/actions/query/parseQuery.ts
@@ -8,6 +8,7 @@ interface Payload {
   query: string;
   ignore_synthetic?: boolean;
   prefer_non_synthetic?: boolean;
+  collections?: string[];
 }
 
 const parseQuery = async (
@@ -15,12 +16,14 @@ const parseQuery = async (
   options?: {
     ignoreSynthetic?: boolean;
     preferNonSynthetic?: boolean;
+    collections?: string[];
   },
 ): Promise<ApiResponse<string>> => {
   return await apiPost<ApiResponse<string>, Payload>(API_ROUTES.parseQuery, {
     query,
     ignore_synthetic: options?.ignoreSynthetic,
     prefer_non_synthetic: options?.preferNonSynthetic,
+    collections: options?.collections,
   });
 };
 

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -60,6 +60,7 @@ const CohortQueryInput = ({
   const includeSynthetic = useQueryBuilder(
     (qb) => qb.hasSelectedSyntheticDatasets,
   );
+  const selectedDatasets = useQueryBuilder((qb) => qb.selectedDatasets);
   const appendError = useQueryBuilder((qb) => qb.appendError);
   const select = useQueryBuilder((qb) => qb.select);
   const errors = useQueryBuilder((qb) => qb.errors ?? []);
@@ -141,13 +142,13 @@ const CohortQueryInput = ({
       if (v === programmaticValueRef.current) return;
 
       queryClient.prefetchQuery({
-        queryKey: ["cohortRules", v, includeSynthetic],
+        queryKey: ["cohortRules", v, includeSynthetic, selectedDatasets],
         queryFn: () =>
-          getQueryFromText(v, { ignoreSynthetic: !includeSynthetic }),
+          getQueryFromText(v, { ignoreSynthetic: !includeSynthetic, collections: selectedDatasets }),
         staleTime: STALE_TIME,
       });
     },
-    [getQueryFromText, queryClient, includeSynthetic],
+    [getQueryFromText, queryClient, includeSynthetic, selectedDatasets],
   );
 
   const handleSearch = useCallback(
@@ -195,9 +196,9 @@ const CohortQueryInput = ({
       }
 
       const queryJson = await queryClient.fetchQuery({
-        queryKey: ["cohortRules", q, includeSynthetic],
+        queryKey: ["cohortRules", q, includeSynthetic, selectedDatasets],
         queryFn: () =>
-          getQueryFromText(q, { ignoreSynthetic: !includeSynthetic }),
+          getQueryFromText(q, { ignoreSynthetic: !includeSynthetic, collections: selectedDatasets }),
         staleTime: STALE_TIME,
       });
 
@@ -249,6 +250,7 @@ const CohortQueryInput = ({
       resetQuery,
       setQueryBuilderJson,
       includeSynthetic,
+      selectedDatasets,
       queryMode,
       queryBuilderJson,
       select,

--- a/src/components/SearchConcepts/ConceptItem.tsx
+++ b/src/components/SearchConcepts/ConceptItem.tsx
@@ -101,6 +101,8 @@ export const ConceptItem = ({
       )}
       {showCounts && (
         <>
+          <Chip color="success" size="small" label={concept.collection_score} />
+          <Chip color="success" size="small" label={concept.match_score} />
           <Tooltip title="Number of datasets present in">
             <Chip color="success" size="small" label={concept.ncollections} />
           </Tooltip>

--- a/src/components/SearchConcepts/ConceptItem.tsx
+++ b/src/components/SearchConcepts/ConceptItem.tsx
@@ -101,8 +101,6 @@ export const ConceptItem = ({
       )}
       {showCounts && (
         <>
-          <Chip color="success" size="small" label={concept.collection_score} />
-          <Chip color="success" size="small" label={concept.match_score} />
           <Tooltip title="Number of datasets present in">
             <Chip color="success" size="small" label={concept.ncollections} />
           </Tooltip>

--- a/src/store/queryBuilderStore.ts
+++ b/src/store/queryBuilderStore.ts
@@ -356,12 +356,7 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
   createNewRule: () => get().createNewNode(NodeKind.RULE),
   createNewGroup: () => get().createNewNode(NodeKind.GROUP),
   createNewOperator: () => get().createNewNode(NodeKind.OPERATOR),
-<<<<<<< Updated upstream
   createNewAgeFilter: () => get().createNewNode(NodeKind.AGE_FILTER),
-=======
-  createNewDemographicFilter: () =>
-    get().createNewNode(NodeKind.DEMOGRAPHIC_FILTER),
->>>>>>> Stashed changes
 
   queryAsText: queryToText(DEFAULT_QUERY),
 

--- a/src/store/queryBuilderStore.ts
+++ b/src/store/queryBuilderStore.ts
@@ -115,7 +115,11 @@ export interface QueryBuilderStoreState {
   queryAsText: string;
   getQueryFromText: (
     input: string,
-    options?: { commit?: boolean; ignoreSynthetic?: boolean },
+    options?: {
+      commit?: boolean;
+      ignoreSynthetic?: boolean;
+      collections?: string[];
+    },
   ) => Promise<RuleGroupType>;
 
   previouslySelectedDatasets: string[];
@@ -352,7 +356,12 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
   createNewRule: () => get().createNewNode(NodeKind.RULE),
   createNewGroup: () => get().createNewNode(NodeKind.GROUP),
   createNewOperator: () => get().createNewNode(NodeKind.OPERATOR),
+<<<<<<< Updated upstream
   createNewAgeFilter: () => get().createNewNode(NodeKind.AGE_FILTER),
+=======
+  createNewDemographicFilter: () =>
+    get().createNewNode(NodeKind.DEMOGRAPHIC_FILTER),
+>>>>>>> Stashed changes
 
   queryAsText: queryToText(DEFAULT_QUERY),
 
@@ -520,7 +529,12 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
     {
       commit = false,
       ignoreSynthetic = false,
-    }: { commit?: boolean; ignoreSynthetic?: boolean } = {},
+      collections,
+    }: {
+      commit?: boolean;
+      ignoreSynthetic?: boolean;
+      collections?: string[];
+    } = {},
   ) => {
     const cleanQuery = (queryString: string) => {
       const query = JSON.parse(queryString) as RuleGroupType;
@@ -531,7 +545,9 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
     };
     const { data: newQueryString } = await parseQuery(input, {
       ignoreSynthetic,
+      collections,
     });
+
     const newQuery = cleanQuery(newQueryString);
     return commit ? get().setQueryBuilderJson(newQuery) : newQuery;
   },


### PR DESCRIPTION
## Summary

* passes collection ids currently selected to the parse query tool

## Jira

<!-- Required: link ticket(s), e.g. https://hdruk.atlassian.net/browse/DP-1234 -->

## PR Type

- [ ] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<!-- For UI work, add before/after screenshots or short video. -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
