### PR TITLE
feat(DP-904): add term directory search

### DIFF
--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -10,6 +10,7 @@ import { getTagTermDirectory } from "@/config/tags";
 const getTermDirectory = async (
   page = 1,
   per_page = DEFAULT_PER_PAGE,
+  search?: string,
 ): Promise<ApiResponse<Paginated<TermDirectoryEntry>>> => {
   const {
     user: { id: userId },
@@ -19,6 +20,11 @@ const getTermDirectory = async (
     page: String(page),
     per_page: String(per_page),
   });
+
+  if (search) {
+    params.set("concept_name", search);
+    params.set("concept_id", search);
+  }
 
   const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({
     url: API_ROUTES.termDirectory,

--- a/src/app/(protected)/term-directory/page.tsx
+++ b/src/app/(protected)/term-directory/page.tsx
@@ -3,20 +3,19 @@ import { Suspense } from "react";
 import Title from "@/components/Title";
 import TermDirectory from "@/modules/TermDirectory";
 import getTermDirectory from "@/actions/termDirectory/getTermDirectory";
+import { ApiSearchParams } from "@/types/api";
 
 interface PageProps {
-  searchParams: Promise<{
-    page?: string;
-    per_page?: string;
-    search_term?: string;
-  }>;
+  searchParams: Promise<ApiSearchParams>;
 }
 
 const TermDirectoryPageContent = async ({ searchParams }: PageProps) => {
   const params = await searchParams;
-  const page = params?.page ? parseInt(params.page) : undefined;
-  const perPage = params?.per_page ? parseInt(params.per_page) : undefined;
-  const result = await getTermDirectory(page, perPage, params?.search_term);
+  const result = await getTermDirectory(
+    params?.page,
+    params?.per_page,
+    params?.search_term,
+  );
 
   return (
     <Paper sx={{ p: 2, gap: 2, display: "flex", flexDirection: "column" }}>

--- a/src/app/(protected)/term-directory/page.tsx
+++ b/src/app/(protected)/term-directory/page.tsx
@@ -5,14 +5,18 @@ import TermDirectory from "@/modules/TermDirectory";
 import getTermDirectory from "@/actions/termDirectory/getTermDirectory";
 
 interface PageProps {
-  searchParams: Promise<{ page?: string; per_page?: string }>;
+  searchParams: Promise<{
+    page?: string;
+    per_page?: string;
+    search_term?: string;
+  }>;
 }
 
 const TermDirectoryPageContent = async ({ searchParams }: PageProps) => {
   const params = await searchParams;
   const page = params?.page ? parseInt(params.page) : undefined;
   const perPage = params?.per_page ? parseInt(params.per_page) : undefined;
-  const result = await getTermDirectory(page, perPage);
+  const result = await getTermDirectory(page, perPage, params?.search_term);
 
   return (
     <Paper sx={{ p: 2, gap: 2, display: "flex", flexDirection: "column" }}>

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -1,12 +1,21 @@
 import "@testing-library/jest-dom";
 import { render, screen, within } from "@testing-library/react";
 import TermDirectory from "./TermDirectory";
+import { DefaultProvider } from "@/providers/DefaultProvider";
 import { mockTermDirectoryEntries } from "@/actions/termDirectory/__mocks__/getTermDirectory";
 import { paginateData } from "@/utils/mock";
+import { TermDirectoryEntry, Paginated } from "@/types/api";
+
+const renderComponent = (entries: Paginated<TermDirectoryEntry>) =>
+  render(
+    <DefaultProvider>
+      <TermDirectory entries={entries} />
+    </DefaultProvider>,
+  );
 
 describe("TermDirectory", () => {
   it("renders the correct column headers", () => {
-    render(<TermDirectory entries={paginateData({ data: mockTermDirectoryEntries })} />);
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
 
     const columns = ["OMOP ID", "Term Name", "Count", "Associated Collections"];
     for (const column of columns) {
@@ -17,7 +26,7 @@ describe("TermDirectory", () => {
   });
 
   it("renders a row per entry with its OMOP id, name and collection count", () => {
-    render(<TermDirectory entries={paginateData({ data: mockTermDirectoryEntries })} />);
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
 
     const firstRow = screen.getByRole("row", {
       name: /Type 2 diabetes mellitus/i,
@@ -33,14 +42,22 @@ describe("TermDirectory", () => {
   });
 
   it("renders the count, formatted with thousands separators for readability", () => {
-    render(<TermDirectory entries={paginateData({ data: mockTermDirectoryEntries })} />);
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
 
     expect(screen.getByText("1,234")).toBeInTheDocument();
   });
 
   it("shows an empty message when no terms are returned", () => {
-    render(<TermDirectory entries={paginateData({ data: [] })} />);
+    renderComponent(paginateData({ data: [] }));
 
     expect(screen.getByText("No terms found.")).toBeInTheDocument();
+  });
+
+  it("renders a search box so users can filter the directory", () => {
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
+
+    expect(
+      screen.getByPlaceholderText("Search by term name or OMOP ID..."),
+    ).toBeInTheDocument();
   });
 });

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -53,7 +53,17 @@ const TermDirectory = ({
     enableStickyHeader: true,
   });
 
-  return <Table table={table} emptyMessage="No terms found." />;
+  return (
+    <Table
+      table={table}
+      emptyMessage="No terms found."
+      leftAction={{
+        searchProps: {
+          placeholder: "Search by term name or OMOP ID...",
+        },
+      }}
+    />
+  );
 };
 
 export default TermDirectory;


### PR DESCRIPTION
## Summary
Adds a search bar to the Term Directory table and allows for searching by term name or concept id.

Adjusts server page and action to accommodate for this change.

Reuses the project's custom `Table` component's search slot as the main UI change.

Adds 1 new unit test.

## Jira
Main ticket:
[https://hdruk.atlassian.net/browse/DP-904](https://hdruk.atlassian.net/browse/DP-904)

There's a related BE bugfix that fixes the name search not working (more context there):
https://hdruk.atlassian.net/browse/DP-947

## PR Type
- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [X] `test`
- [ ] `perf`

## PR Title Check
This repo validates PR titles in CI. Use one of:
- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included
- [x] UI changes
- [x] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [x] Test updates
- [ ] Documentation updates

## Validation
Run locally before requesting review:
- [x] `npm run lint` passes
- [x] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist
- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<img width="1569" height="604" alt="image" src="https://github.com/user-attachments/assets/42bce862-1efb-46c1-8933-d274660b21ab" />


## Risk and Rollback

## Notes for Reviewers
