### PR TITLE
feat(DP-905): add term directory collection filter

### DIFF
--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -13,6 +13,7 @@ const getTermDirectory = async (
   per_page = DEFAULT_PER_PAGE,
   search?: string,
   domain?: DomainTab,
+  collections?: string[],
 ): Promise<ApiResponse<Paginated<TermDirectoryEntry>>> => {
   const {
     user: { id: userId },
@@ -37,6 +38,8 @@ const getTermDirectory = async (
       params.set("domain_id", domainIds[0]);
     }
   }
+
+  collections?.forEach((pid) => params.append("collection_pid[]", pid));
 
   const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({
     url: API_ROUTES.termDirectory,

--- a/src/app/(protected)/term-directory/page.tsx
+++ b/src/app/(protected)/term-directory/page.tsx
@@ -1,7 +1,8 @@
-import { Paper, Skeleton } from "@mui/material";
+import { Paper, Skeleton, Stack } from "@mui/material";
 import { Suspense } from "react";
 import Title from "@/components/Title";
 import TermDirectory from "@/modules/TermDirectory";
+import CollectionFilter from "@/modules/TermDirectory/CollectionFilter";
 import getTermDirectory from "@/actions/termDirectory/getTermDirectory";
 import { TermDirectorySearchParams } from "@/types/api";
 import { getDomainPhrase } from "@/utils/omop";
@@ -18,6 +19,7 @@ const TermDirectoryPageContent = async ({ searchParams }: PageProps) => {
     params?.per_page,
     params?.search_term,
     params?.domain,
+    params?.collections?.split(","),
   );
 
   return (
@@ -30,13 +32,21 @@ const TermDirectoryPageContent = async ({ searchParams }: PageProps) => {
         bgcolor: "background.default",
       }}
     >
-      <Title
-        title="Term Directory"
-        subTitle={
-          params?.domain &&
-          capitaliseFirstLetter(getDomainPhrase(params.domain).noun)
-        }
-      />
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        gap={2}
+      >
+        <Title
+          title="Term Directory"
+          subTitle={
+            params?.domain &&
+            capitaliseFirstLetter(getDomainPhrase(params.domain).noun)
+          }
+        />
+        <CollectionFilter />
+      </Stack>
       <TermDirectory entries={result.data} />
     </Paper>
   );

--- a/src/modules/TermDirectory/CollectionFilter.test.tsx
+++ b/src/modules/TermDirectory/CollectionFilter.test.tsx
@@ -1,0 +1,65 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CollectionFilter from "./CollectionFilter";
+import { DefaultProvider } from "@/providers/DefaultProvider";
+import { getMockCollection } from "@/actions/collection/__mocks__/getCollections";
+import { useUserDataStore } from "@/hooks/userDataStore";
+
+const mockReplace = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => "/term-directory",
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: mockReplace,
+  }),
+}));
+
+const collections = [
+  getMockCollection({ id: 1, pid: "col-pid-1", name: "Test Dataset Alpha" }),
+  getMockCollection({ id: 2, pid: "col-pid-2", name: "Test Dataset Beta" }),
+];
+
+const renderComponent = () =>
+  render(
+    <DefaultProvider>
+      <CollectionFilter />
+    </DefaultProvider>,
+  );
+
+const openPopover = async () =>
+  userEvent.click(screen.getByRole("button", { name: "Filter by collection" }));
+
+describe("CollectionFilter", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockSearchParams = new URLSearchParams();
+    useUserDataStore.setState({ userCollections: collections });
+  });
+
+  it("writes a checked collection to the URL and restarts at page 1", async () => {
+    renderComponent();
+
+    await openPopover();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Test Dataset Beta" }),
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith("?collections=col-pid-2&page=1");
+  });
+
+  it("removes the param when the last collection is unchecked", async () => {
+    mockSearchParams = new URLSearchParams("collections=col-pid-1");
+    renderComponent();
+
+    await openPopover();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Test Dataset Alpha" }),
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith("?page=1");
+  });
+});

--- a/src/modules/TermDirectory/CollectionFilter.tsx
+++ b/src/modules/TermDirectory/CollectionFilter.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import {
+  Box,
+  Chip,
+  FormControlLabel,
+  Popover,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { useCallback, useMemo, useState } from "react";
+import { filterDatasetChipSx } from "@/components/FilterDatasets/FilterDatasets";
+import SearchBox from "@/components/SearchBox";
+import SquareCheckbox from "@/components/SquareCheckbox";
+import Title from "@/components/Title";
+import { useDebounce } from "@/hooks/useDebounce";
+import { useUserDataStore } from "@/hooks/userDataStore";
+import useSearchParams from "@/hooks/useSearchParams";
+import { GroupedCollection } from "@/types/api";
+
+const COLLECTIONS_PARAM = "collections";
+
+const CollectionFilter = () => {
+  const { searchParams, setSearchParams } = useSearchParams();
+  const userCollections = useUserDataStore((state) => state.userCollections);
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [searchTerm, setSearchTerm] = useState<string>();
+  const { debounced: debouncedSearchTerm } = useDebounce(searchTerm, {});
+
+  const selectedPids = useMemo(
+    () => searchParams.get(COLLECTIONS_PARAM)?.split(",") ?? [],
+    [searchParams],
+  );
+
+  const filteredCollections = useMemo(() => {
+    const term = debouncedSearchTerm?.trim().toLowerCase();
+    if (term && term.length > 2) {
+      return userCollections.filter((collection) =>
+        collection.name.toLowerCase().includes(term),
+      );
+    }
+    return userCollections;
+  }, [userCollections, debouncedSearchTerm]);
+
+  const groupedCollections = useMemo(
+    () =>
+      Object.values(
+        filteredCollections.reduce<Record<number, GroupedCollection>>(
+          (acc, collection) => {
+            const { custodian } = collection;
+            (acc[custodian.id] ??= { custodian, items: [] }).items.push(
+              collection,
+            );
+            return acc;
+          },
+          {},
+        ),
+      ),
+    [filteredCollections],
+  );
+
+  const toggleCollection = useCallback(
+    (pid: string) => {
+      const next = selectedPids.includes(pid)
+        ? selectedPids.filter((selected) => selected !== pid)
+        : [...selectedPids, pid];
+
+      setSearchParams({
+        [COLLECTIONS_PARAM]: next.length ? next.join(",") : null,
+        page: "1",
+      });
+    },
+    [selectedPids, setSearchParams],
+  );
+
+  const open = Boolean(anchorEl);
+
+  return (
+    <Title title="Filter" subTitle="Collections">
+      <Chip
+        aria-label="Filter by collection"
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        sx={{
+          bgcolor: open ? "secondary.main" : "white",
+          color: open ? "secondary.contrastText" : "inherit",
+          ...filterDatasetChipSx,
+        }}
+        label={
+          <Box
+            sx={{
+              width: "100%",
+              display: "flex",
+              alignItems: "baseline",
+              flexWrap: "nowrap",
+            }}
+          >
+            {selectedPids.length > 0 && (
+              <Chip
+                label={selectedPids.length}
+                sx={{
+                  bgcolor: "background.default",
+                  color: "background.contrastText",
+                  borderRadius: 10,
+                  mr: 0.5,
+                }}
+              />
+            )}
+            <Typography variant="body1" color="inherit">
+              {selectedPids.length > 0 ? "Selected" : "All"}
+            </Typography>
+          </Box>
+        }
+      />
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        <Stack
+          sx={{ p: 2, gap: 0.5, minWidth: 320, maxHeight: 400, overflow: "auto" }}
+        >
+          <SearchBox
+            placeholder="I'm looking for..."
+            collapsible={false}
+            inputBgColor="background.default"
+            onChange={(event) => setSearchTerm(event.target.value)}
+          />
+          {groupedCollections.map(({ custodian, items }) => (
+            <Stack key={custodian.id} sx={{ gap: 0.5, mt: 1 }}>
+              <Typography variant="subtitle2" color="text.secondary">
+                {custodian.name}
+              </Typography>
+              {items.map((collection) => (
+                <FormControlLabel
+                  key={collection.pid}
+                  control={
+                    <SquareCheckbox
+                      checked={selectedPids.includes(collection.pid)}
+                      onChange={() => toggleCollection(collection.pid)}
+                    />
+                  }
+                  label={collection.name}
+                />
+              ))}
+            </Stack>
+          ))}
+          {!filteredCollections.length && (
+            <Typography>No collections found.</Typography>
+          )}
+        </Stack>
+      </Popover>
+    </Title>
+  );
+};
+
+export default CollectionFilter;

--- a/src/modules/TermDirectory/CollectionFilter.tsx
+++ b/src/modules/TermDirectory/CollectionFilter.tsx
@@ -34,16 +34,16 @@ const CollectionFilter = () => {
   );
 
   const filteredCollections = useMemo(() => {
-    const term = debouncedSearchTerm?.trim().toLowerCase();
-    if (term && term.length > 2) {
+    const searchTerm = debouncedSearchTerm?.trim().toLowerCase();
+    if (searchTerm && searchTerm.length > 2) {
       return userCollections.filter((collection) =>
-        collection.name.toLowerCase().includes(term),
+        collection.name.toLowerCase().includes(searchTerm),
       );
     }
     return userCollections;
   }, [userCollections, debouncedSearchTerm]);
 
-  const groupedCollections = useMemo(
+  const custodianGroups = useMemo(
     () =>
       Object.values(
         filteredCollections.reduce<Record<number, GroupedCollection>>(
@@ -128,7 +128,7 @@ const CollectionFilter = () => {
             inputBgColor="background.default"
             onChange={(event) => setSearchTerm(event.target.value)}
           />
-          {groupedCollections.map(({ custodian, items }) => (
+          {custodianGroups.map(({ custodian, items }) => (
             <Stack key={custodian.id} sx={{ gap: 0.5, mt: 1 }}>
               <Typography variant="subtitle2" color="text.secondary">
                 {custodian.name}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -37,6 +37,7 @@ export interface ConceptSearchParams extends ApiSearchParams {
 
 export interface TermDirectorySearchParams extends ApiSearchParams {
   domain?: DomainTab;
+  collections?: string;
 }
 
 export interface CacheOptions {


### PR DESCRIPTION
## Summary

Adds a collection filter to the term directory page, using the same style for the button as the main query builder collection filter, but with a more lightweight selection UI. Uses URL params just like the search and domain tab features before this.

## Jira

https://hdruk.atlassian.net/browse/DP-905

## PR Type

- [X] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [X] API integration changes (`src/actions/*`)
- [X] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [X] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [X] `npm run test` passes
- [X] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

https://github.com/user-attachments/assets/2772b974-f506-42ad-ad53-6a8df5f0b28e

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
