### PR TITLE
fix(DP-955): search bar auto select on initial load

### DIFF
--- a/src/app/(protected)/dashboard/[tabId]/components/CohortBuilderClient.tsx
+++ b/src/app/(protected)/dashboard/[tabId]/components/CohortBuilderClient.tsx
@@ -80,7 +80,7 @@ const CohortBuilderClient = ({
             display="flex"
           >
             <Stack direction="column" spacing={1} sx={{ flex: 1, minWidth: 0 }}>
-              <CohortQueryInput queries={userQueries} />
+              <CohortQueryInput queries={userQueries} autoFocus />
               <Divider />
             </Stack>
           </Stack>

--- a/src/components/CohortQueryInput/CohortQueryInput.test.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.test.tsx
@@ -161,6 +161,28 @@ describe("CohortQueryInput", () => {
     expect(await screen.findByText("Query Examples")).toBeInTheDocument();
   });
 
+  it("hides the examples once 3+ characters are typed and shows them again below 3", async () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    const input = getSearchInput();
+
+    await user.click(input);
+
+    expect(await screen.findByText("Query Examples")).toBeInTheDocument();
+
+    await user.type(input, "zzz");
+
+    await waitFor(() =>
+      expect(screen.queryByText("Query Examples")).not.toBeInTheDocument(),
+    );
+
+    await user.keyboard("{Backspace}");
+
+    expect(await screen.findByText("Query Examples")).toBeInTheDocument();
+  });
+
   it("does not update queryBuilderJson while typing, then updates when Enter is pressed", async () => {
     const user = userEvent.setup();
 

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -41,12 +41,14 @@ type CohortQueryInputProps = {
   queries: Query[];
   syncFromQueryAsText?: boolean;
   resetOnSearch?: boolean;
+  autoFocus?: boolean;
 };
 
 const CohortQueryInput = ({
   queries,
   syncFromQueryAsText = false,
   resetOnSearch = true,
+  autoFocus = false,
 }: CohortQueryInputProps) => {
   const defaults = useDefaults();
 
@@ -100,20 +102,18 @@ const CohortQueryInput = ({
   useEffect(() => {
     /*
      * Intentional exception to react-hooks/set-state-in-effect:
-     * queryMode/openSearchOverlap are transient local UI states tied to the
-     * current query builder contents.
+     * queryMode is a transient local UI state tied to the current query
+     * builder contents.
      *
      * If the rules change outside this component (which they can do),
      * the previous mode may no longer be valid.
      * Resetting it forces the user back through the mode choice when
      * requiresQueryModeChoice becomes true.
      *
-     * Functional setters prevent redundant updates if already reset.
+     * Functional setter prevents redundant updates if already reset.
      */
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setQueryMode((current) => (current === null ? current : null));
-
-    setOpenSearchOverlap((current) => (current ? false : current));
   }, [rulesKey]);
 
   const resetQuery = useCallback(() => {
@@ -371,14 +371,21 @@ const CohortQueryInput = ({
             color: isAppendMode ? "success.main" : "inherit",
           };
 
+          const inputTooShort =
+            String(field.value ?? "").trim().length < MIN_SEARCH_LENGTH;
+
           const showSearchOverlay =
-            !showChoicePrompt && !isAppendMode && openSearchOverlap;
+            !showChoicePrompt &&
+            !isAppendMode &&
+            openSearchOverlap &&
+            inputTooShort;
 
           return (
             <Box display="flex" flexDirection="row" sx={{ gap: 1 }}>
               <Box ref={anchorRef} sx={{ flex: 1 }}>
                 <SearchBox
                   {...field}
+                  autoFocus={autoFocus}
                   startIcon={<SearchIcon fontSize="medium" sx={{ ml: 2 }} />}
                   collapsible={false}
                   error={isDirty && !!error}
@@ -434,10 +441,6 @@ const CohortQueryInput = ({
                     programmaticValueRef.current = null;
 
                     field.onChange(e);
-
-                    if (e.target.value || isAppendMode) {
-                      setOpenSearchOverlap(false);
-                    }
                   }}
                 />
 

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -28,7 +28,6 @@ type FormValues = {
   cohortQueryInput: string;
 };
 
-
 enum QueryMode {
   FRESH = "fresh",
   APPEND = "append",
@@ -72,6 +71,15 @@ const CohortQueryInput = ({
 
   const [queryMode, setQueryMode] = useState<QueryMode | null>(null);
   const [openSearchOverlap, setOpenSearchOverlap] = useState(false);
+
+  /*
+   * On the initial auto-focus we want the box focused but the examples overlay
+   * hidden until the user starts typing. Any later focus (or interaction)
+   * should pop the examples open as normal, so this only guards that first
+   * pristine focus and is cleared as soon as the user types or blurs.
+   */
+  const [suppressInitialExamples, setSuppressInitialExamples] =
+    useState(autoFocus);
 
   const programmaticValueRef = useRef<string | null>(null);
   const lastSyncedQueryAsText = useRef<string | null>(null);
@@ -144,7 +152,10 @@ const CohortQueryInput = ({
       queryClient.prefetchQuery({
         queryKey: ["cohortRules", v, includeSynthetic, selectedDatasets],
         queryFn: () =>
-          getQueryFromText(v, { ignoreSynthetic: !includeSynthetic, collections: selectedDatasets }),
+          getQueryFromText(v, {
+            ignoreSynthetic: !includeSynthetic,
+            collections: selectedDatasets,
+          }),
         staleTime: STALE_TIME,
       });
     },
@@ -198,7 +209,10 @@ const CohortQueryInput = ({
       const queryJson = await queryClient.fetchQuery({
         queryKey: ["cohortRules", q, includeSynthetic, selectedDatasets],
         queryFn: () =>
-          getQueryFromText(q, { ignoreSynthetic: !includeSynthetic, collections: selectedDatasets }),
+          getQueryFromText(q, {
+            ignoreSynthetic: !includeSynthetic,
+            collections: selectedDatasets,
+          }),
         staleTime: STALE_TIME,
       });
 
@@ -360,7 +374,10 @@ const CohortQueryInput = ({
           },
         }}
         render={({ field, fieldState: { error, isDirty } }) => {
-          const hasInput = String(field.value ?? "").trim().length > 0;
+          const trimmedInputLength = String(field.value ?? "").trim().length;
+          const hasInput = trimmedInputLength > 0;
+          const inputTooShort = trimmedInputLength < MIN_SEARCH_LENGTH;
+
           const showChoicePrompt = requiresQueryModeChoice && !hasInput;
 
           const searchDisabled = showChoicePrompt || !!error || !hasInput;
@@ -371,14 +388,12 @@ const CohortQueryInput = ({
             color: isAppendMode ? "success.main" : "inherit",
           };
 
-          const inputTooShort =
-            String(field.value ?? "").trim().length < MIN_SEARCH_LENGTH;
-
           const showSearchOverlay =
             !showChoicePrompt &&
             !isAppendMode &&
             openSearchOverlap &&
-            inputTooShort;
+            inputTooShort &&
+            (hasInput || !suppressInitialExamples);
 
           return (
             <Box display="flex" flexDirection="row" sx={{ gap: 1 }}>
@@ -435,12 +450,16 @@ const CohortQueryInput = ({
                   }}
                   onBlur={() => {
                     field.onBlur();
+                    setSuppressInitialExamples(false);
                     setTimeout(() => setOpenSearchOverlap(false), 150);
                   }}
                   onChange={(e) => {
                     programmaticValueRef.current = null;
 
                     field.onChange(e);
+
+                    setSuppressInitialExamples(false);
+                    setOpenSearchOverlap(true);
                   }}
                 />
 

--- a/src/components/CohortQueryTitle/CohortQueryTitle.tsx
+++ b/src/components/CohortQueryTitle/CohortQueryTitle.tsx
@@ -18,6 +18,7 @@ const CohortQueryTitle = () => {
       subTitle={
         <EditableText
           singleClick
+          autoFocus={false}
           defaultValue={queryName || ""}
           onCommit={(name) => {
             if (name.length >= 3) {

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -23,6 +23,7 @@ export type EditableTextProps = {
   showIcon?: boolean;
   singleClick?: boolean;
   editing?: boolean;
+  autoFocus?: boolean;
 };
 
 type FormValues = {
@@ -41,8 +42,9 @@ const EditableText = ({
   showIcon = false,
   singleClick = false,
   editing: editingProp,
+  autoFocus = true,
 }: EditableTextProps) => {
-  const [editing, setEditing] = useState(!defaultValue);
+  const [editing, setEditing] = useState(autoFocus ? !defaultValue : false);
   const [hovering, setHovering] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -160,7 +162,7 @@ const EditableText = ({
             render={({ field, fieldState: { error } }) => (
               <TextField
                 id={STABLE_ID}
-                autoFocus
+                autoFocus={autoFocus}
                 inputRef={inputRef}
                 {...field}
                 error={!!error}


### PR DESCRIPTION

## Summary

On the dashboard, the cursor now auto-focuses the main search bar instead of the Query Name field. Example queries stay hidden on initial load and appear once you start typing (and while the input is under 3 characters); they still pop open immediately on any later focus.


https://github.com/user-attachments/assets/0e4c2de6-86c0-438e-914d-2d577e20e79e



## Jira

https://hdruk.atlassian.net/browse/DP-955

## PR Type

- [x] `fix`

## Changes Included

- [x] UI changes

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes

## Risk and Rollback

- Risk level: low
- Main risk areas: search bar focus / examples overlay on the dashboard
- Rollback plan: revert PR
