### PR TITLE
feat(DP-997): add an "All" domain filter tab in term directory

### DIFF
--- a/src/modules/TermDirectory/DomainFilterTabs.test.tsx
+++ b/src/modules/TermDirectory/DomainFilterTabs.test.tsx
@@ -50,4 +50,22 @@ describe("DomainFilterTabs", () => {
       "true",
     );
   });
+
+  it("does nothing when clicking the already-selected domain tab", async () => {
+    mockSearchParams = new URLSearchParams("domain=observation");
+    render(<DomainFilterTabs />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Observation" }));
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("clears the domain filter when clicking All while a domain is selected", async () => {
+    mockSearchParams = new URLSearchParams("domain=observation");
+    render(<DomainFilterTabs />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "All" }));
+
+    expect(mockReplace).toHaveBeenCalledWith("?page=1");
+  });
 });

--- a/src/modules/TermDirectory/DomainFilterTabs.tsx
+++ b/src/modules/TermDirectory/DomainFilterTabs.tsx
@@ -9,10 +9,13 @@ import { capitaliseFirstLetter } from "@/utils/string";
 const DomainFilterTabs = () => {
   const { getSearchParam, setSearchParams } = useSearchParams("domain");
 
-  const selected = getSearchParam() ?? false;
+  const selected = getSearchParam() ?? "all";
 
   const setDomain = (value: string | null) =>
-    setSearchParams({ domain: value, page: "1" });
+    setSearchParams({
+      domain: value === "all" ? null : value,
+      page: "1",
+    });
 
   return (
     <Tabs
@@ -22,14 +25,12 @@ const DomainFilterTabs = () => {
       scrollButtons="auto"
       aria-label="Filter terms by domain"
     >
+      <Tab label="All" value="all" />
       {DOMAIN_TABS.map((domain) => (
         <Tab
           key={domain}
           label={capitaliseFirstLetter(getDomainPhrase(domain).noun)}
           value={domain}
-          onClick={() => {
-            if (domain === selected) setDomain(null);
-          }}
         />
       ))}
     </Tabs>


### PR DESCRIPTION
## Summary

Before this, the only way to reset the domain filter was to click again on a selected filter which wasn't very obvious. This adds an “All” tab at the far left which is selected by default and simply clears the "domain" URL param.

The domain tabs also can't be toggled off by re-clicking them anymore, that's what the "All" tab is for now.

## Jira

https://hdruk.atlassian.net/browse/DP-997

## PR Type

- [X] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [X] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<img width="722" height="157" alt="image" src="https://github.com/user-attachments/assets/c6beb295-1f27-4efc-8b09-616dc3258789" />

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
