### PR TITLE
feat(DP-998): add Domain column to term directory table

### DIFF
--- a/src/actions/termDirectory/__mocks__/getTermDirectory.ts
+++ b/src/actions/termDirectory/__mocks__/getTermDirectory.ts
@@ -17,6 +17,7 @@ export const mockTermDirectoryEntries: TermDirectoryEntry[] = [
   getMockTermDirectoryEntry({
     concept_id: 4329847,
     concept_name: "Myocardial infarction",
+    domain_id: "Observation",
     count: 50,
     ncollections: 1,
   }),

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -21,7 +21,13 @@ describe("TermDirectory", () => {
   it("renders the correct column headers", () => {
     renderComponent(paginateData({ data: mockTermDirectoryEntries }));
 
-    const columns = ["OMOP ID", "Term Name", "Count", "Associated Collections"];
+    const columns = [
+      "OMOP ID",
+      "Term Name",
+      "Domain",
+      "Count",
+      "Associated Collections",
+    ];
     for (const column of columns) {
       expect(
         screen.getByRole("columnheader", { name: new RegExp(column) }),
@@ -87,5 +93,19 @@ describe("TermDirectory", () => {
 
     expect(writeText).toHaveBeenCalledWith("201826");
     expect(await screen.findByText("Copied to clipboard")).toBeInTheDocument();
+  });
+
+  it("renders each term's domain", () => {
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
+
+    const firstRow = screen.getByRole("row", {
+      name: /Type 2 diabetes mellitus/i,
+    });
+    expect(within(firstRow).getByText("Condition")).toBeInTheDocument();
+
+    const secondRow = screen.getByRole("row", {
+      name: /Myocardial infarction/i,
+    });
+    expect(within(secondRow).getByText("Observation")).toBeInTheDocument();
   });
 });

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -41,6 +41,12 @@ const TermDirectory = ({
         size: 400,
       },
       {
+        id: "domain_id",
+        header: "Domain",
+        accessorFn: (row) => row.domain_id,
+        size: 140,
+      },
+      {
         id: "count",
         header: "Count",
         accessorFn: (row) => row.count,


### PR DESCRIPTION
## Summary

Currently there isn’t a way to tell what domain a given concept in the Term Directory is which is relevant info. This adds a new column in between the "Term Name" and the "count" columns in the table to address that.

## Jira

https://hdruk.atlassian.net/browse/DP-998

## PR Type

- [X] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [X] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [X] `npm run lint` passes
- [X] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<img width="231" height="536" alt="image" src="https://github.com/user-attachments/assets/32477270-9132-4ffb-a1bd-1198d7d6bc07" />

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
