### PR TITLE
fix(DP-983): drag overlay crash from missing CloseGuardProvider

### DIFF
--- a/src/components/DragOverlay/DragOverlay.tsx
+++ b/src/components/DragOverlay/DragOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { createContext } from "react";
 import { DragOverlay as DndDragOverlay } from "@dnd-kit/core";
+import { CloseGuardProvider } from "@/providers/CloseGuardProvider";
 
 import {
   hasAlternatives,
@@ -38,9 +39,12 @@ const DragOverlay = ({ node }: { node: RuleNodeType | null }) => {
   return (
     <DndDragOverlay>
       {node ? (
-        <DragOverlayRenderContext.Provider value={true}>
-          {renderRule(node)}
-        </DragOverlayRenderContext.Provider>
+        // Overlay is portaled outside SwimLane's CloseGuardProvider, so give clones their own.
+        <CloseGuardProvider>
+          <DragOverlayRenderContext.Provider value={true}>
+            {renderRule(node)}
+          </DragOverlayRenderContext.Provider>
+        </CloseGuardProvider>
       ) : null}
     </DndDragOverlay>
   );

--- a/src/components/DragOverlay/DragOverlay.tsx
+++ b/src/components/DragOverlay/DragOverlay.tsx
@@ -39,7 +39,6 @@ const DragOverlay = ({ node }: { node: RuleNodeType | null }) => {
   return (
     <DndDragOverlay>
       {node ? (
-        // Overlay is portaled outside SwimLane's CloseGuardProvider, so give clones their own.
         <CloseGuardProvider>
           <DragOverlayRenderContext.Provider value={true}>
             {renderRule(node)}


### PR DESCRIPTION
> ⚠️ **AI disclaimer:** Claude (Anthropic) was used to write the PR summary
## Summary

Fixes a crash (`useCloseGuard must be used within CloseGuardProvider`) that occurred when starting to drag a rule in the query builder.

`@dnd-kit`'s `<DragOverlay>` portals the dragged clone to `document.body`, outside the `CloseGuardProvider` that lives inside `SwimLane`. Since DP-848 (Super Rule) the cloned `RuleSearch` calls `useSaveChanges` → `useCloseGuard`, which threw because the context was `null` in the portaled subtree. The fix wraps the overlay's rendered content in its own isolated `CloseGuardProvider`.

## Jira

https://hdruk.atlassian.net/browse/DP-983

## PR Type

- [x] `fix`

## PR Title Check

- `fix(DP-983): drag overlay crash from missing CloseGuardProvider`

## Changes Included

- [x] UI changes

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [ ] `npm run test` passes (pre-existing failures in unrelated `__mocks__`/test files; no new failures from this change)
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts`
- [x] API calls follow existing patterns
- [x] Side-effectful endpoints are not cached unintentionally
- [x] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

_Manual repro: select/create a rule, then drag it — previously the page crashed with the "This page couldn't load" error boundary; after the fix the drag works normally._

## Risk and Rollback

- Risk level: low
- Main risk areas:
  - Drag-and-drop in the query builder (rule/group/operator drag overlay rendering)
- Rollback plan:
  - Revert this PR

## Notes for Reviewers

- The overlay is a throwaway visual clone, so giving it an isolated `CloseGuardProvider` is intentional — it preserves the `throw`-on-missing-provider safety net everywhere else while satisfying the clone's `useCloseGuard` dependency.
- The branch is currently 1 commit behind `origin/dev`; the only substantive change here is `src/components/DragOverlay/DragOverlay.tsx`.
