### PR TITLE
feat(DP-1017): sort term directory results across all pages instead of just one

### DIFF
--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -14,6 +14,7 @@ const getTermDirectory = async (
   search?: string,
   domain?: DomainTab,
   collections?: string[],
+  sort?: string,
 ): Promise<ApiResponse<Paginated<TermDirectoryEntry>>> => {
   const {
     user: { id: userId },
@@ -40,6 +41,10 @@ const getTermDirectory = async (
   }
 
   collections?.forEach((pid) => params.append("collection_pid[]", pid));
+
+  if (sort) {
+    params.set("sort", sort);
+  }
 
   const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({
     url: API_ROUTES.termDirectory,

--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -7,6 +7,10 @@ import { TermDirectoryEntry, ApiResponse, Paginated } from "@/types/api";
 import { DEFAULT_PER_PAGE } from "@/config/defaults";
 import { DOMAIN_TAB_FILTERS, DomainTab } from "@/config/domainFilters";
 import { getTagTermDirectory } from "@/config/tags";
+import { SortDirection } from "@/types/common";
+
+const SORTABLE_FIELDS = ["concept_name", "count", "ncollections"];
+const SORT_DIRECTIONS: string[] = Object.values(SortDirection);
 
 const getTermDirectory = async (
   page = 1,
@@ -43,7 +47,14 @@ const getTermDirectory = async (
   collections?.forEach((pid) => params.append("collection_pid[]", pid));
 
   if (sort) {
-    params.set("sort", sort);
+    const [field, direction] = sort.split(":");
+
+    if (
+      SORTABLE_FIELDS.includes(field) &&
+      SORT_DIRECTIONS.includes(direction)
+    ) {
+      params.set("sort", sort);
+    }
   }
 
   const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({

--- a/src/app/(protected)/term-directory/page.tsx
+++ b/src/app/(protected)/term-directory/page.tsx
@@ -20,6 +20,7 @@ const TermDirectoryPageContent = async ({ searchParams }: PageProps) => {
     params?.search_term,
     params?.domain,
     params?.collections?.split(","),
+    params?.sort,
   );
 
   return (

--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -7,10 +7,12 @@ import {
   MRT_RowData,
   MRT_TableOptions,
   MRT_SortingState,
+  MRT_Updater,
 } from "material-react-table";
 import { useTable } from "./useTable";
 import { buildRowsPerPageOptions } from "@/utils/pagination";
 import { DEFAULT_PER_PAGE } from "@/config/defaults";
+import { SortDirection } from "@/types/common";
 
 interface UsePaginatedTableOptions<TData extends MRT_RowData> extends Partial<
   MRT_TableOptions<TData>
@@ -24,6 +26,9 @@ interface UsePaginatedTableOptions<TData extends MRT_RowData> extends Partial<
 
   pageParam?: string;
   perPageParam?: string;
+
+  sortParam?: string;
+  serverSorting?: boolean;
 }
 
 export function usePaginatedTable<TData extends MRT_RowData>({
@@ -35,6 +40,8 @@ export function usePaginatedTable<TData extends MRT_RowData>({
   getRowId = (row) => row?.pid ?? String(row?.id || ""),
   pageParam = "page",
   perPageParam = "per_page",
+  sortParam = "sort",
+  serverSorting = false,
   state,
   initialState,
   ...rest
@@ -57,6 +64,40 @@ export function usePaginatedTable<TData extends MRT_RowData>({
   });
 
   const [sorting, setSorting] = useState<MRT_SortingState>([]);
+
+  const [sortField, sortDirection] = (searchParams.get(sortParam) ?? "").split(
+    ":",
+  );
+
+  const urlSorting: MRT_SortingState = sortField
+    ? [{ id: sortField, desc: sortDirection === SortDirection.DESCENDING }]
+    : [];
+
+  const handleSortingChange = (
+    updaterOrValue: MRT_Updater<MRT_SortingState>,
+  ) => {
+    const nextSorting =
+      typeof updaterOrValue === "function"
+        ? updaterOrValue(urlSorting)
+        : updaterOrValue;
+
+    const [column] = nextSorting;
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (column) {
+      const direction = column.desc
+        ? SortDirection.DESCENDING
+        : SortDirection.ASCENDING;
+
+      params.set(sortParam, `${column.id}:${direction}`);
+    } else {
+      params.delete(sortParam);
+    }
+
+    params.set(pageParam, "1");
+
+    router.replace(`?${params.toString()}`);
+  };
 
   /*useEffect(() => {
     const collapsed = sorting
@@ -107,15 +148,16 @@ export function usePaginatedTable<TData extends MRT_RowData>({
     enablePagination: true,
     manualPagination: true,
     enableSorting: true,
+    manualSorting: serverSorting,
     onPaginationChange: setPagination,
-    onSortingChange: setSorting,
+    onSortingChange: serverSorting ? handleSortingChange : setSorting,
     initialState: {
       ...initialState,
       expanded,
     },
     state: {
       pagination,
-      sorting,
+      sorting: serverSorting ? urlSorting : sorting,
       ...state,
     },
     muiPaginationProps: {

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { Stack } from "@mui/material";
-import { type MRT_ColumnDef } from "material-react-table";
+import {
+  type MRT_ColumnDef,
+  type MRT_SortingState,
+} from "material-react-table";
 import { useMemo } from "react";
 import { TermDirectoryEntry, Paginated } from "@/types/api";
+import { SortDirection } from "@/types/common";
 import { usePaginatedTable } from "@/hooks/usePaginatedTable";
+import useSearchParams from "@/hooks/useSearchParams";
 import CopyableTextButton from "@/components/CopyableTextButton";
 import Table from "@/components/Table";
 import { formatNumber } from "@/utils/numbers";
@@ -57,6 +62,14 @@ const TermDirectory = ({
     [],
   );
 
+  const { getSearchParam, setSearchParams } = useSearchParams("sort");
+
+  const [sortField, sortDirection] = (getSearchParam() ?? "").split(":");
+
+  const sorting: MRT_SortingState = sortField
+    ? [{ id: sortField, desc: sortDirection === SortDirection.DESCENDING }]
+    : [];
+
   const table = usePaginatedTable<TermDirectoryEntry>({
     columns,
     data: entries.data,
@@ -64,6 +77,25 @@ const TermDirectory = ({
     perPageDefault: DEFAULT_PER_PAGE,
     getRowId: (row) => String(row?.concept_id),
     enableStickyHeader: true,
+    manualSorting: true,
+    state: { sorting },
+    onSortingChange: (updaterOrValue) => {
+      const nextSorting =
+        typeof updaterOrValue === "function"
+          ? updaterOrValue(sorting)
+          : updaterOrValue;
+
+      const [column] = nextSorting;
+
+      const direction = column?.desc
+        ? SortDirection.DESCENDING
+        : SortDirection.ASCENDING;
+
+      setSearchParams({
+        sort: column ? `${column.id}:${direction}` : null,
+        page: "1",
+      });
+    },
   });
 
   return (

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -26,6 +26,7 @@ const TermDirectory = ({
       {
         id: "concept_id",
         header: "OMOP ID",
+        enableSorting: false,
         accessorFn: (row) => row.concept_id,
         Cell: ({ cell }) => (
           <Stack direction="row" alignItems="center">

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -1,15 +1,10 @@
 "use client";
 
 import { Stack } from "@mui/material";
-import {
-  type MRT_ColumnDef,
-  type MRT_SortingState,
-} from "material-react-table";
+import { type MRT_ColumnDef } from "material-react-table";
 import { useMemo } from "react";
 import { TermDirectoryEntry, Paginated } from "@/types/api";
-import { SortDirection } from "@/types/common";
 import { usePaginatedTable } from "@/hooks/usePaginatedTable";
-import useSearchParams from "@/hooks/useSearchParams";
 import CopyableTextButton from "@/components/CopyableTextButton";
 import Table from "@/components/Table";
 import { formatNumber } from "@/utils/numbers";
@@ -63,14 +58,6 @@ const TermDirectory = ({
     [],
   );
 
-  const { getSearchParam, setSearchParams } = useSearchParams("sort");
-
-  const [sortField, sortDirection] = (getSearchParam() ?? "").split(":");
-
-  const sorting: MRT_SortingState = sortField
-    ? [{ id: sortField, desc: sortDirection === SortDirection.DESCENDING }]
-    : [];
-
   const table = usePaginatedTable<TermDirectoryEntry>({
     columns,
     data: entries.data,
@@ -78,25 +65,7 @@ const TermDirectory = ({
     perPageDefault: DEFAULT_PER_PAGE,
     getRowId: (row) => String(row?.concept_id),
     enableStickyHeader: true,
-    manualSorting: true,
-    state: { sorting },
-    onSortingChange: (updaterOrValue) => {
-      const nextSorting =
-        typeof updaterOrValue === "function"
-          ? updaterOrValue(sorting)
-          : updaterOrValue;
-
-      const [column] = nextSorting;
-
-      const direction = column?.desc
-        ? SortDirection.DESCENDING
-        : SortDirection.ASCENDING;
-
-      setSearchParams({
-        sort: column ? `${column.id}:${direction}` : null,
-        page: "1",
-      });
-    },
+    serverSorting: true,
   });
 
   return (


### PR DESCRIPTION
## Summary

The term directory table sorted client side so it only reordered the current page. Sorting is now sent to the API which already supports it, so it applies across all results.

Also disables sorting of OMOP ID as it's not part of the agreed sort options.

## Jira

https://hdruk.atlassian.net/browse/DP-1017

## PR Type

- [ ] `feat`
- [X] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [X] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [X] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

### Before (one page sorting):

https://github.com/user-attachments/assets/ddf31570-7997-450d-b4ad-bab7d4c65cb9

### After (entire results sorting):

https://github.com/user-attachments/assets/e0459f84-e8f2-4be1-8499-5c47a3c52cd2

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
