### PR TITLE
feat(DP-857): demographics panel UI

### DIFF
--- a/src/components/SwimLane/SwimLane.tsx
+++ b/src/components/SwimLane/SwimLane.tsx
@@ -31,6 +31,7 @@ export interface SwimLaneProps extends GridProps {
   hideOnTransiton?: boolean;
   paperSx?: PaperProps["sx"];
   enableBlocker?: boolean;
+  topSlot?: React.ReactNode;
 }
 
 const SwimLane = ({
@@ -40,6 +41,7 @@ const SwimLane = ({
   size,
   paperSx,
   enableBlocker = false,
+  topSlot,
   ...rest
 }: SwimLaneProps) => {
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -137,6 +139,18 @@ const SwimLane = ({
           {...rest}
           size={size}
         >
+          {topSlot && (
+            <Paper
+              sx={{
+                flexShrink: 0,
+                p: 2,
+                mr: 1,
+                mb: 2,
+              }}
+            >
+              {!isTransitioning && topSlot}
+            </Paper>
+          )}
           <Paper
             sx={{
               display: "flex",

--- a/src/hooks/useFeatures.ts
+++ b/src/hooks/useFeatures.ts
@@ -50,6 +50,9 @@ const useFeatures = () => {
 
         queryBuilderUseValueAsNumber:
           flags[FeatureName.QueryBuilderUseValueAsNumber],
+
+        queryBuilderUseDemographicRule:
+          flags[FeatureName.QueryBuilderUseDemographicRule],
       };
     }),
   );

--- a/src/modules/DemographicsPanel/DemographicAgeSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicAgeSection.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { Chip } from "@mui/material";
+import useQueryBuilder from "@/hooks/useQueryBuilder";
+import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
+import DemographicRow from "./DemographicRow";
+import DemographicAgeSelector from "./DemographicAgeSelector";
+import { formatAgeSummary } from "./summary";
+
+const DEFAULT_AGE_RANGE: [number, number] = [MIN_AGE_FILTER, MAX_AGE_FILTER];
+
+const DemographicAgeSection = () => {
+  const { age, setAge } = useQueryBuilder((qb) => ({
+    age: qb.queryBuilderJson.demographics?.age ?? null,
+    setAge: qb.setDemographicsAge,
+  }));
+
+  const [editing, setEditing] = useState(false);
+
+  const handleEdit = () => {
+    if (!age) setAge(DEFAULT_AGE_RANGE);
+    setEditing(true);
+  };
+
+  const handleClear = () => {
+    setAge(null);
+    setEditing(false);
+  };
+
+  return (
+    <DemographicRow
+      label="Age"
+      onEdit={editing ? undefined : handleEdit}
+      onClear={handleClear}
+      showClear={age !== null}
+    >
+      {editing && age ? (
+        <DemographicAgeSelector value={age} onChange={setAge} />
+      ) : (
+        <Chip
+          variant="outlined"
+          sx={{ bgcolor: "white" }}
+          label={formatAgeSummary(age)}
+        />
+      )}
+    </DemographicRow>
+  );
+};
+
+export default DemographicAgeSection;

--- a/src/modules/DemographicsPanel/DemographicAgeSelector.tsx
+++ b/src/modules/DemographicsPanel/DemographicAgeSelector.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Slider, Stack, TextField } from "@mui/material";
+import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
+
+interface DemographicAgeSelectorProps {
+  value: [number, number];
+  onChange: (value: [number, number]) => void;
+}
+
+const clampRange = (l: number, r: number): [number, number] => [
+  Math.max(MIN_AGE_FILTER, Math.min(l, r)),
+  Math.min(MAX_AGE_FILTER, Math.max(l, r)),
+];
+
+const numberFieldSx = {
+  maxWidth: "7ch",
+  flexShrink: 0,
+  "& .MuiOutlinedInput-root": { borderRadius: 1 },
+};
+
+const numberInputProps = {
+  step: 1,
+  min: MIN_AGE_FILTER,
+  max: MAX_AGE_FILTER,
+  type: "number",
+  "aria-labelledby": "demographic-age-slider",
+  sx: { p: 0.5 },
+};
+
+const DemographicAgeSelector = ({
+  value,
+  onChange,
+}: DemographicAgeSelectorProps) => {
+  const [draft, setDraft] = useState<[number, number] | null>(null);
+  const current = useMemo(() => draft ?? value, [draft, value]);
+
+  const commit = (next: [number, number]) => {
+    setDraft(null);
+    onChange(clampRange(next[0], next[1]));
+  };
+
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+      alignItems="center"
+      sx={{ flex: 1, py: 1 }}
+    >
+      <TextField
+        value={current[0]}
+        size="small"
+        onChange={(e) =>
+          setDraft([e.target.value === "" ? 0 : Number(e.target.value), current[1]])
+        }
+        onBlur={() => commit(current)}
+        onKeyDown={(e) => e.key === "Enter" && commit(current)}
+        slotProps={{ htmlInput: numberInputProps }}
+        sx={numberFieldSx}
+      />
+      <Slider
+        value={current}
+        min={MIN_AGE_FILTER}
+        max={MAX_AGE_FILTER}
+        onChange={(_e, next) => setDraft(next as [number, number])}
+        onChangeCommitted={(_e, next) => commit(next as [number, number])}
+        aria-labelledby="demographic-age-slider"
+      />
+      <TextField
+        value={current[1]}
+        size="small"
+        onChange={(e) =>
+          setDraft([current[0], e.target.value === "" ? 0 : Number(e.target.value)])
+        }
+        onBlur={() => commit(current)}
+        onKeyDown={(e) => e.key === "Enter" && commit(current)}
+        slotProps={{ htmlInput: numberInputProps }}
+        sx={numberFieldSx}
+      />
+    </Stack>
+  );
+};
+
+export default DemographicAgeSelector;

--- a/src/modules/DemographicsPanel/DemographicConceptSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicConceptSection.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Chip, Stack } from "@mui/material";
+import { Concept } from "@/types/api";
+import SearchConcepts from "@/components/SearchConcepts";
+import ConceptChip from "@/components/ConceptChip";
+import DemographicRow from "./DemographicRow";
+
+interface DemographicConceptSectionProps {
+  label: string;
+  domain: string;
+  concepts: Concept[];
+  onToggle: (concept: Concept, selected: boolean) => void;
+  onClear: () => void;
+}
+
+const toSelectedMap = (concepts: Concept[]): Record<number, boolean> =>
+  Object.fromEntries(concepts.map((c) => [c.concept_id, true]));
+
+const DemographicConceptSection = ({
+  label,
+  domain,
+  concepts,
+  onToggle,
+  onClear,
+}: DemographicConceptSectionProps) => {
+  const [editing, setEditing] = useState(false);
+  const [selected, setSelected] = useState<Record<number, boolean>>({});
+
+  const startEditing = () => {
+    setSelected(toSelectedMap(concepts));
+    setEditing(true);
+  };
+
+  const handleRemove = (concept: Concept) => {
+    setSelected((prev) => ({ ...prev, [concept.concept_id]: false }));
+    onToggle(concept, false);
+  };
+
+  const handleClear = () => {
+    onClear();
+    setEditing(false);
+  };
+
+  const selectedChips = concepts.length > 0 && (
+    <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: editing ? 1 : 0 }}>
+      {concepts.map((c) => (
+        <ConceptChip
+          key={c.concept_id}
+          concept={c}
+          onDelete={(e) => {
+            e.stopPropagation();
+            handleRemove(c);
+          }}
+        />
+      ))}
+    </Stack>
+  );
+
+  return (
+    <DemographicRow
+      label={label}
+      onEdit={editing ? undefined : startEditing}
+      onClear={handleClear}
+      showClear={concepts.length > 0}
+    >
+      {editing ? (
+        <Box>
+          <SearchConcepts
+            domain={domain}
+            multiple
+            selected={selected}
+            setSelected={setSelected}
+            onToggle={onToggle}
+          />
+          {selectedChips}
+          <Button
+            variant="text"
+            size="small"
+            sx={{ mt: 1 }}
+            onClick={() => setEditing(false)}
+          >
+            Done
+          </Button>
+        </Box>
+      ) : (
+        selectedChips || (
+          <Chip variant="outlined" sx={{ bgcolor: "white" }} label="Any" />
+        )
+      )}
+    </DemographicRow>
+  );
+};
+
+export default DemographicConceptSection;

--- a/src/modules/DemographicsPanel/DemographicRow.tsx
+++ b/src/modules/DemographicsPanel/DemographicRow.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ReactNode } from "react";
+import { Box, Button, IconButton, Stack, Typography } from "@mui/material";
+import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+
+interface DemographicRowProps {
+  label: string;
+  onEdit?: () => void;
+  onClear?: () => void;
+  showClear?: boolean;
+  children: ReactNode;
+}
+
+const DemographicRow = ({
+  label,
+  onEdit,
+  onClear,
+  showClear = false,
+  children,
+}: DemographicRowProps) => (
+  <Stack
+    direction="row"
+    alignItems="flex-start"
+    spacing={1}
+    sx={{ py: 1, width: "100%" }}
+  >
+    <Typography
+      variant="body2"
+      color="text.secondary"
+      sx={{
+        minWidth: 44,
+        minHeight: 32,
+        display: "flex",
+        alignItems: "center",
+        flexShrink: 0,
+      }}
+    >
+      {label} /
+    </Typography>
+
+    <Box sx={{ flex: 1, minWidth: 0 }}>{children}</Box>
+
+    <Stack
+      direction="row"
+      alignItems="center"
+      spacing={0.5}
+      sx={{ minHeight: 32, flexShrink: 0 }}
+    >
+      {onEdit && (
+        <IconButton size="small" aria-label={`Edit ${label}`} onClick={onEdit}>
+          <EditOutlinedIcon fontSize="small" />
+        </IconButton>
+      )}
+      {showClear && onClear && (
+        <Button variant="text" size="small" color="secondary" onClick={onClear}>
+          Clear all
+        </Button>
+      )}
+    </Stack>
+  </Stack>
+);
+
+export default DemographicRow;

--- a/src/modules/DemographicsPanel/DemographicsPanel.tsx
+++ b/src/modules/DemographicsPanel/DemographicsPanel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Collapse,
+  Divider,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import AccordionExpandIcon from "@/components/AccordionExpandIcon";
+import { OmopTableName } from "@/types/omop";
+import useQueryBuilder from "@/hooks/useQueryBuilder";
+import DemographicAgeSection from "./DemographicAgeSection";
+import DemographicConceptSection from "./DemographicConceptSection";
+import { formatAgeSummary, formatConceptCountSummary } from "./summary";
+
+// Race is scaffolded in state and payload but not yet surfaced (DP-857 defers it).
+const SHOW_RACE = false;
+
+const DemographicsPanel = () => {
+  const { demographics, remove, toggleSex, clearSex, toggleRace, clearRace } =
+    useQueryBuilder((qb) => ({
+      demographics: qb.queryBuilderJson.demographics,
+      remove: qb.removeDemographics,
+      toggleSex: qb.toggleDemographicsSex,
+      clearSex: qb.clearDemographicsSex,
+      toggleRace: qb.toggleDemographicsRace,
+      clearRace: qb.clearDemographicsRace,
+    }));
+
+  const age = demographics?.age ?? null;
+  const sex = demographics?.sex ?? [];
+  const race = demographics?.race ?? [];
+  const hasBeenConfigured = Boolean(age || sex.length || race.length);
+
+  const [expanded, setExpanded] = useState(true);
+
+  const summary = [
+    formatAgeSummary(age),
+    formatConceptCountSummary("Sex", sex),
+    ...(SHOW_RACE ? [formatConceptCountSummary("Race", race)] : []),
+  ].join(" · ");
+
+  return (
+    <Box data-marquee-ignore="true">
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        spacing={1}
+      >
+        <Stack
+          direction="row"
+          alignItems="baseline"
+          spacing={1}
+          sx={{ minWidth: 0 }}
+        >
+          <Typography variant="overline" color="text.secondary">
+            Demographic Rule
+          </Typography>
+          {!expanded && (
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {summary}
+            </Typography>
+          )}
+        </Stack>
+
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Tooltip title={expanded ? "Collapse" : "Expand"}>
+            <IconButton
+              aria-label={
+                expanded ? "Collapse demographics" : "Expand demographics"
+              }
+              onClick={() => setExpanded((prev) => !prev)}
+            >
+              <AccordionExpandIcon expanded={expanded} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Remove demographic rule">
+            <IconButton aria-label="Remove demographic rule" onClick={remove}>
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Stack>
+
+      <Collapse in={expanded}>
+        <Divider sx={{ mb: 1 }} />
+
+        {!hasBeenConfigured && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            Set your demographic criteria below. Each category defaults to Any.
+          </Typography>
+        )}
+
+        <DemographicAgeSection />
+
+        <DemographicConceptSection
+          label="Sex"
+          domain={OmopTableName.Gender}
+          concepts={sex}
+          onToggle={toggleSex}
+          onClear={clearSex}
+        />
+
+        {SHOW_RACE && (
+          <DemographicConceptSection
+            label="Race"
+            domain={OmopTableName.Race}
+            concepts={race}
+            onToggle={toggleRace}
+            onClear={clearRace}
+          />
+        )}
+      </Collapse>
+    </Box>
+  );
+};
+
+export default DemographicsPanel;

--- a/src/modules/DemographicsPanel/index.ts
+++ b/src/modules/DemographicsPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DemographicsPanel";

--- a/src/modules/DemographicsPanel/summary.test.ts
+++ b/src/modules/DemographicsPanel/summary.test.ts
@@ -1,0 +1,20 @@
+import { Concept } from "@/types/api";
+import { formatAgeSummary, formatConceptCountSummary } from "./summary";
+
+const concept = (concept_id: number): Concept =>
+  ({ concept_id, name: `c${concept_id}`, category: "Gender" }) as Concept;
+
+describe("demographics summary formatters", () => {
+  it("formats age range and Any", () => {
+    expect(formatAgeSummary([18, 65])).toBe("Age 18–65");
+    expect(formatAgeSummary(null)).toBe("Age Any");
+  });
+
+  it("formats concept counts with pluralisation and Any", () => {
+    expect(formatConceptCountSummary("Sex", [])).toBe("Sex Any");
+    expect(formatConceptCountSummary("Sex", [concept(1)])).toBe("1 Sex concept");
+    expect(formatConceptCountSummary("Sex", [concept(1), concept(2)])).toBe(
+      "2 Sex concepts",
+    );
+  });
+});

--- a/src/modules/DemographicsPanel/summary.ts
+++ b/src/modules/DemographicsPanel/summary.ts
@@ -1,0 +1,12 @@
+import { Concept } from "@/types/api";
+
+export const formatAgeSummary = (age: [number, number] | null): string =>
+  age ? `Age ${age[0]}–${age[1]}` : "Age Any";
+
+export const formatConceptCountSummary = (
+  label: string,
+  concepts: Concept[],
+): string =>
+  concepts.length === 0
+    ? `${label} Any`
+    : `${concepts.length} ${label} concept${concepts.length === 1 ? "" : "s"}`;

--- a/src/modules/QueryBuilder/QueryBuilder.tsx
+++ b/src/modules/QueryBuilder/QueryBuilder.tsx
@@ -12,6 +12,7 @@ import ThreePaneSwimLaneLayout from "../ThreePaneSwimLaneLayout";
 import { ThreePaneProvider } from "@/providers/ThreePaneProvider";
 import { useLeaveConfirmation } from "@/hooks/useLeaveConfirmation";
 import RuleBoard from "../RuleBoard";
+import DemographicsPanel from "../DemographicsPanel";
 import { CohortBuilderProvider } from "@/providers/CohortBuilderProvider";
 import useFeatures from "@/hooks/useFeatures";
 
@@ -22,7 +23,8 @@ const QueryBuilder = ({
   query?: Query;
   errorOnDrag?: boolean;
 }) => {
-  const { queryBuilderLeaveConfirm } = useFeatures();
+  const { queryBuilderLeaveConfirm, queryBuilderUseDemographicRule } =
+    useFeatures();
   const { queryBuilderJson, setQueryBuilderJson, select, deselect } =
     useQueryBuilder((qb) => ({
       queryBuilderJson: qb.queryBuilderJson,
@@ -31,6 +33,10 @@ const QueryBuilder = ({
       deselect: qb.deselect,
       selectedGuidance: qb.selectedGuidance,
     }));
+
+  const showDemographics =
+    queryBuilderUseDemographicRule && !!queryBuilderJson.demographics;
+
   useEffect(() => {
     if (query?.definition) {
       setQueryBuilderJson(query.definition);
@@ -63,18 +69,21 @@ const QueryBuilder = ({
               <QueryBuilderSkeleton />
             )
           }
-          middleProps={{ ref: boardRef }}
+          middleProps={{
+            ref: boardRef,
+            topSlot: showDemographics ? <DemographicsPanel /> : undefined,
+          }}
           right={<RuleMenu />}
           rightDisabled={
             !queryBuilderJson ||
-            (queryBuilderJson?.rules && queryBuilderJson.rules.length === 0)
+            (queryBuilderJson.rules.length === 0 && !showDemographics)
           }
         />
         <MarqueeSelection
           containerRef={boardRef}
           selectable='[data-selectable="true"]'
           idAttr="data-id"
-          ignoreWhenInside='[data-draggable="true"]'
+          ignoreWhenInside='[data-draggable="true"], [data-marquee-ignore="true"]'
           onChange={onChangeSelection}
         />
       </ThreePaneProvider>

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -23,6 +23,7 @@ export enum FeatureName {
   AdminMoreCollectionDetails = "admin-more-collection-details",
 
   QueryBuilderUseValueAsNumber = "query-builder-use-value-as-number",
+  QueryBuilderUseDemographicRule = "query-builder-use-demographic-rule",
 }
 
 export type FeatureFlag = Record<FeatureName, boolean>;
@@ -54,4 +55,6 @@ export const DEFAULT_FLAGS: FeatureFlag = {
   [FeatureName.AdminMoreCollectionDetails]: false,
 
   [FeatureName.QueryBuilderUseValueAsNumber]: false,
+
+  [FeatureName.QueryBuilderUseDemographicRule]: false,
 };


### PR DESCRIPTION
> **🤖 AI assistance disclosure:** This change was implemented with the help of Claude (Claude Code). All code has been reviewed by the author before submission.

## Summary

**Stack 2 of 3 for DP-857 (Demographics Panel).** Builds on Stack 1 (state + contract). Adds the user-facing **Demographics panel**, rendered **inside the query builder's centre swimlane** (flanked by the Insert menu on the left and guidance on the right), separate from the query rule tree.

- **Optional and absent by default** — the panel appears only once added (via "Add demographic rule", Stack 3), is collapsible, and is **removable via an ×** that resets it and hides it again.
- Live collapsed **summary** (e.g. `Age 50–65 · 2 Sex concepts`) that updates automatically as selections change.
- **Age** section (controlled slider) and **Sex** section (concept multi-select via existing `SearchConcepts` on the `gender` domain, chips via `ConceptChip`).
- **Independent per-section edit and Clear all** — clearing a section resets only it to *Any*, leaving others untouched.
- **Race** is scaffolded in state/payload but its UI is hidden for now (`SHOW_RACE = false`), per "Sex now, Race in future".
- Adds panel-presence state (`visible` / `show` / `remove`) to the demographics store.
- Defines the **`query-builder-use-demographic-rule`** feature flag (`FeatureName` + `DEFAULT_FLAGS` + `useFeatures`, default off) and gates the panel render + right-pane guidance on it. The Insert-menu switch that uses this flag lands in Stack 3.

## Jira

https://hdruk.atlassian.net/browse/DP-857

## PR Type

- [x] `feat`

## PR Title Check

`feat(DP-857): demographics panel UI`

## Changes Included

- [x] UI changes (new `src/modules/DemographicsPanel/`)
- [x] Test updates (`summary.test.ts`)

Key files:
- `src/modules/DemographicsPanel/*` — panel shell (collapse + summary + remove), Age row + controlled slider, reusable concept multi-select (Sex now, Race later), row layout, summary formatter (+ test).
- `src/components/SwimLane/SwimLane.tsx` — new optional `topSlot` that renders a separate stacked lane card above the lane's main content (additive, defaults to nothing → no change for other lanes).
- `src/modules/ThreePaneSwimLaneLayout/ThreePaneSwimLaneLayout.tsx` — new optional `middleTop` prop forwarded to the middle lane's `topSlot`.
- `src/modules/QueryBuilder/QueryBuilder.tsx` — passes the panel as `middleTop` (shown only when visible).
- `src/app/(protected)/dashboard/[tabId]/components/CohortBuilderClient.tsx` — removes the old full-width mount.

Reuses existing components: `SearchConcepts`, `ConceptChip`, `AccordionExpandIcon`, `RuleAgeSelector` constants.

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes (summary formatter tests added; full suite green)
- [ ] `npm run build` — pre-existing test-file type-check collision only (see Stack 1 note); non-test source clean.

## Coding Conventions Checklist

- [x] Searched `src/components` first; reuses existing library components
- [x] PascalCase components, `@/` imports
- [x] No raw MUI Dialog/Tabs/Table introduced

## Screenshots / Evidence

_To add: before/after of the New Query page with the Demographics panel expanded and collapsed._

## Risk and Rollback

- Risk level: low–medium (adds a panel to the New Query page)
- Main risk areas: New Query page layout; concept search for Sex
- Rollback plan: revert PR; panel is self-contained and unmounting it restores the prior page.

## Notes for Reviewers

Depends on Stack 1. The panel drives the Stack 1 demographics store; nothing here changes the query tree.
