### PR TITLE
feat(DP-857): configurable checkbox Sex selector in demographics panel

### DIFF
--- a/src/config/demographics.test.ts
+++ b/src/config/demographics.test.ts
@@ -1,0 +1,24 @@
+import {
+  SEX_CONCEPTS,
+  demographicOptionToConcept,
+} from "@/config/demographics";
+
+describe("demographics config", () => {
+  it("exposes sex options with unique concept ids", () => {
+    const ids = SEX_CONCEPTS.map((o) => o.concept_id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(SEX_CONCEPTS.length).toBeGreaterThan(0);
+  });
+
+  it("maps an option to a Concept with a Gender category", () => {
+    const concept = demographicOptionToConcept({
+      concept_id: 8507,
+      name: "Male",
+    });
+    expect(concept).toEqual({
+      concept_id: 8507,
+      name: "Male",
+      category: "Gender",
+    });
+  });
+});

--- a/src/config/demographics.ts
+++ b/src/config/demographics.ts
@@ -1,0 +1,31 @@
+import { Concept } from "@/types/api";
+
+/**
+ * Fixed demographic concept options rendered as checkboxes in the Demographics
+ * panel. Curated by hand here so the shown values can be decided without a
+ * round-trip to the API. This could be sourced from an endpoint in the future.
+ *
+ * concept_id values should be confirmed against the OMOP vocabulary in use.
+ */
+export interface DemographicOption {
+  concept_id: number;
+  name: string;
+}
+
+export const SEX_CONCEPTS: DemographicOption[] = [
+  { concept_id: 8532, name: "Female" },
+  { concept_id: 8507, name: "Male" },
+  { concept_id: 0, name: "No matching concept" },
+  { concept_id: 8551, name: "Unknown" },
+];
+
+export const SEX_GUIDANCE =
+  "Define the patient sex criteria that should apply. Patient sex information may be unavailable or incomplete in some records.";
+
+export const demographicOptionToConcept = (
+  option: DemographicOption,
+): Concept => ({
+  concept_id: option.concept_id,
+  name: option.name,
+  category: "Gender",
+});

--- a/src/modules/DemographicsPanel/DemographicAgeSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicAgeSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { Chip } from "@mui/material";
+import { Box, Chip } from "@mui/material";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
 import DemographicRow from "./DemographicRow";
@@ -16,34 +15,31 @@ const DemographicAgeSection = () => {
     setAge: qb.setDemographicsAge,
   }));
 
-  const [editing, setEditing] = useState(false);
-
   const handleEdit = () => {
     if (!age) setAge(DEFAULT_AGE_RANGE);
-    setEditing(true);
   };
 
   const handleClear = () => {
     setAge(null);
-    setEditing(false);
   };
 
   return (
     <DemographicRow
       label="Age"
-      onEdit={editing ? undefined : handleEdit}
+      onEdit={handleEdit}
       onClear={handleClear}
       showClear={age !== null}
+      renderEditing={
+        <Box minWidth={350} maxWidth={400}>
+          {age && <DemographicAgeSelector value={age} onChange={setAge} />}
+        </Box>
+      }
     >
-      {editing && age ? (
-        <DemographicAgeSelector value={age} onChange={setAge} />
-      ) : (
-        <Chip
-          variant="outlined"
-          sx={{ bgcolor: "white" }}
-          label={formatAgeSummary(age)}
-        />
-      )}
+      <Chip
+        variant="outlined"
+        sx={{ bgcolor: "white" }}
+        label={formatAgeSummary(age)}
+      />
     </DemographicRow>
   );
 };

--- a/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useState } from "react";
 import {
-  Button,
   Chip,
   FormControlLabel,
   FormGroup,
@@ -34,24 +32,15 @@ const DemographicCheckboxSection = ({
   onClear,
   note,
 }: DemographicCheckboxSectionProps) => {
-  const [editing, setEditing] = useState(false);
-
   const isChecked = (conceptId: number) =>
     selected.some((c) => c.concept_id === conceptId);
-
-  const handleClear = () => {
-    onClear();
-    setEditing(false);
-  };
 
   return (
     <DemographicRow
       label={label}
-      onEdit={editing ? undefined : () => setEditing(true)}
-      onClear={handleClear}
+      onClear={onClear}
       showClear={selected.length > 0}
-    >
-      {editing ? (
+      renderEditing={
         <>
           <FormGroup>
             {options.map((option) => (
@@ -74,16 +63,10 @@ const DemographicCheckboxSection = ({
               {note}
             </Typography>
           )}
-          <Button
-            variant="text"
-            size="small"
-            sx={{ mt: 1 }}
-            onClick={() => setEditing(false)}
-          >
-            Done
-          </Button>
         </>
-      ) : selected.length > 0 ? (
+      }
+    >
+      {selected.length > 0 ? (
         <Stack direction="row" flexWrap="wrap" gap={0.5}>
           {selected.map((c) => (
             <Chip

--- a/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Button,
+  Chip,
+  FormControlLabel,
+  FormGroup,
+  Stack,
+  Typography,
+} from "@mui/material";
+import SquareCheckbox from "@/components/SquareCheckbox";
+import { Concept } from "@/types/api";
+import {
+  DemographicOption,
+  demographicOptionToConcept,
+} from "@/config/demographics";
+import DemographicRow from "./DemographicRow";
+
+interface DemographicCheckboxSectionProps {
+  label: string;
+  options: DemographicOption[];
+  selected: Concept[];
+  onToggle: (concept: Concept, selected: boolean) => void;
+  onClear: () => void;
+  note?: string;
+}
+
+const DemographicCheckboxSection = ({
+  label,
+  options,
+  selected,
+  onToggle,
+  onClear,
+  note,
+}: DemographicCheckboxSectionProps) => {
+  const [editing, setEditing] = useState(false);
+
+  const isChecked = (conceptId: number) =>
+    selected.some((c) => c.concept_id === conceptId);
+
+  const handleClear = () => {
+    onClear();
+    setEditing(false);
+  };
+
+  return (
+    <DemographicRow
+      label={label}
+      onEdit={editing ? undefined : () => setEditing(true)}
+      onClear={handleClear}
+      showClear={selected.length > 0}
+    >
+      {editing ? (
+        <>
+          <FormGroup>
+            {options.map((option) => (
+              <FormControlLabel
+                key={option.concept_id}
+                control={
+                  <SquareCheckbox
+                    checked={isChecked(option.concept_id)}
+                    onChange={(_e, checked) =>
+                      onToggle(demographicOptionToConcept(option), checked)
+                    }
+                  />
+                }
+                label={option.name}
+              />
+            ))}
+          </FormGroup>
+          {note && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {note}
+            </Typography>
+          )}
+          <Button
+            variant="text"
+            size="small"
+            sx={{ mt: 1 }}
+            onClick={() => setEditing(false)}
+          >
+            Done
+          </Button>
+        </>
+      ) : selected.length > 0 ? (
+        <Stack direction="row" flexWrap="wrap" gap={0.5}>
+          {selected.map((c) => (
+            <Chip
+              key={c.concept_id}
+              variant="outlined"
+              sx={{ bgcolor: "white" }}
+              label={c.name}
+            />
+          ))}
+        </Stack>
+      ) : (
+        <Chip variant="outlined" sx={{ bgcolor: "white" }} label="Any" />
+      )}
+    </DemographicRow>
+  );
+};
+
+export default DemographicCheckboxSection;

--- a/src/modules/DemographicsPanel/DemographicConceptSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicConceptSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Button, Chip, Stack } from "@mui/material";
+import { Box, Chip, Stack } from "@mui/material";
 import { Concept } from "@/types/api";
 import SearchConcepts from "@/components/SearchConcepts";
 import ConceptChip from "@/components/ConceptChip";
@@ -25,26 +25,15 @@ const DemographicConceptSection = ({
   onToggle,
   onClear,
 }: DemographicConceptSectionProps) => {
-  const [editing, setEditing] = useState(false);
   const [selected, setSelected] = useState<Record<number, boolean>>({});
-
-  const startEditing = () => {
-    setSelected(toSelectedMap(concepts));
-    setEditing(true);
-  };
 
   const handleRemove = (concept: Concept) => {
     setSelected((prev) => ({ ...prev, [concept.concept_id]: false }));
     onToggle(concept, false);
   };
 
-  const handleClear = () => {
-    onClear();
-    setEditing(false);
-  };
-
   const selectedChips = concepts.length > 0 && (
-    <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: editing ? 1 : 0 }}>
+    <Stack direction="row" flexWrap="wrap" gap={0.5}>
       {concepts.map((c) => (
         <ConceptChip
           key={c.concept_id}
@@ -61,11 +50,10 @@ const DemographicConceptSection = ({
   return (
     <DemographicRow
       label={label}
-      onEdit={editing ? undefined : startEditing}
-      onClear={handleClear}
+      onEdit={() => setSelected(toSelectedMap(concepts))}
+      onClear={onClear}
       showClear={concepts.length > 0}
-    >
-      {editing ? (
+      renderEditing={
         <Box>
           <SearchConcepts
             domain={domain}
@@ -75,19 +63,11 @@ const DemographicConceptSection = ({
             onToggle={onToggle}
           />
           {selectedChips}
-          <Button
-            variant="text"
-            size="small"
-            sx={{ mt: 1 }}
-            onClick={() => setEditing(false)}
-          >
-            Done
-          </Button>
         </Box>
-      ) : (
-        selectedChips || (
-          <Chip variant="outlined" sx={{ bgcolor: "white" }} label="Any" />
-        )
+      }
+    >
+      {selectedChips || (
+        <Chip variant="outlined" sx={{ bgcolor: "white" }} label="Any" />
       )}
     </DemographicRow>
   );

--- a/src/modules/DemographicsPanel/DemographicRow.tsx
+++ b/src/modules/DemographicsPanel/DemographicRow.tsx
@@ -1,64 +1,109 @@
 "use client";
 
-import { ReactNode } from "react";
-import { Box, Button, IconButton, Stack, Typography } from "@mui/material";
+import { ReactNode, useState } from "react";
+import { Button, Divider, IconButton, Stack } from "@mui/material";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import Title from "@/components/Title";
 
 interface DemographicRowProps {
   label: string;
   onEdit?: () => void;
+  onSave?: () => void;
   onClear?: () => void;
   showClear?: boolean;
   children: ReactNode;
+  renderEditing: ReactNode;
 }
 
 const DemographicRow = ({
   label,
   onEdit,
+  onSave,
   onClear,
   showClear = false,
   children,
-}: DemographicRowProps) => (
-  <Stack
-    direction="row"
-    alignItems="flex-start"
-    spacing={1}
-    sx={{ py: 1, width: "100%" }}
-  >
-    <Typography
-      variant="body2"
-      color="text.secondary"
-      sx={{
-        minWidth: 44,
-        minHeight: 32,
-        display: "flex",
-        alignItems: "center",
-        flexShrink: 0,
-      }}
-    >
-      {label} /
-    </Typography>
+  renderEditing,
+}: DemographicRowProps) => {
+  const [editing, setEditing] = useState(false);
 
-    <Box sx={{ flex: 1, minWidth: 0 }}>{children}</Box>
+  const handleEdit = () => {
+    setEditing(true);
+    onEdit?.();
+  };
 
-    <Stack
-      direction="row"
-      alignItems="center"
-      spacing={0.5}
-      sx={{ minHeight: 32, flexShrink: 0 }}
-    >
-      {onEdit && (
-        <IconButton size="small" aria-label={`Edit ${label}`} onClick={onEdit}>
-          <EditOutlinedIcon fontSize="small" />
-        </IconButton>
+  const handleClear = () => {
+    setEditing(false);
+    onClear?.();
+  };
+  const handleSave = () => {
+    setEditing(false);
+    onSave?.();
+  };
+
+  return (
+    <>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="space-between"
+        spacing={1}
+        sx={{ py: 1, width: "100%" }}
+      >
+        <Title
+          title={label}
+          size={"small"}
+          subTitle={editing ? renderEditing : children}
+          wrapperSx={{ width: "100%" }}
+        />
+
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={0.5}
+          sx={{ minHeight: 32, flexShrink: 0 }}
+        >
+          {!editing && (
+            <IconButton
+              size="small"
+              aria-label={`Edit ${label}`}
+              onClick={handleEdit}
+            >
+              <EditOutlinedIcon fontSize="small" />
+            </IconButton>
+          )}
+          {showClear && !editing && (
+            <Button
+              variant="text"
+              size="small"
+              color="secondary"
+              onClick={handleClear}
+            >
+              Clear all
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+      <Divider />
+      {editing && (
+        <>
+          <Stack
+            direction={"row"}
+            spacing={1}
+            justifyContent={"flex-end"}
+            my={1}
+          >
+            <Button variant="outlined" color="secondary" onClick={handleClear}>
+              Reset Selection{" "}
+            </Button>
+            <Button color="secondary" onClick={handleSave}>
+              Save Selection and Collapse
+            </Button>
+          </Stack>
+          <Divider />
+        </>
       )}
-      {showClear && onClear && (
-        <Button variant="text" size="small" color="secondary" onClick={onClear}>
-          Clear all
-        </Button>
-      )}
-    </Stack>
-  </Stack>
-);
+    </>
+  );
+};
 
 export default DemographicRow;

--- a/src/modules/DemographicsPanel/DemographicsPanel.tsx
+++ b/src/modules/DemographicsPanel/DemographicsPanel.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import {
   Box,
   Collapse,
-  Divider,
   IconButton,
   Stack,
   Tooltip,
@@ -12,39 +11,31 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AccordionExpandIcon from "@/components/AccordionExpandIcon";
-import { OmopTableName } from "@/types/omop";
 import { SEX_CONCEPTS, SEX_GUIDANCE } from "@/config/demographics";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
+import Title from "@/components/Title";
 import DemographicAgeSection from "./DemographicAgeSection";
 import DemographicCheckboxSection from "./DemographicCheckboxSection";
-import DemographicConceptSection from "./DemographicConceptSection";
 import { formatAgeSummary, formatConceptCountSummary } from "./summary";
 
-// Race is scaffolded in state and payload but not yet surfaced (DP-857 defers it).
-const SHOW_RACE = false;
-
 const DemographicsPanel = () => {
-  const { demographics, remove, toggleSex, clearSex, toggleRace, clearRace } =
-    useQueryBuilder((qb) => ({
+  const { demographics, remove, toggleSex, clearSex } = useQueryBuilder(
+    (qb) => ({
       demographics: qb.queryBuilderJson.demographics,
       remove: qb.removeDemographics,
       toggleSex: qb.toggleDemographicsSex,
       clearSex: qb.clearDemographicsSex,
-      toggleRace: qb.toggleDemographicsRace,
-      clearRace: qb.clearDemographicsRace,
-    }));
+    }),
+  );
 
   const age = demographics?.age ?? null;
   const sex = demographics?.sex ?? [];
-  const race = demographics?.race ?? [];
-  const hasBeenConfigured = Boolean(age || sex.length || race.length);
 
   const [expanded, setExpanded] = useState(true);
 
   const summary = [
     formatAgeSummary(age),
     formatConceptCountSummary("Sex", sex),
-    ...(SHOW_RACE ? [formatConceptCountSummary("Race", race)] : []),
   ].join(" · ");
 
   return (
@@ -61,14 +52,17 @@ const DemographicsPanel = () => {
           spacing={1}
           sx={{ minWidth: 0 }}
         >
-          <Typography variant="overline" color="text.secondary">
-            Demographic Rule
-          </Typography>
-          {!expanded && (
-            <Typography variant="body2" color="text.secondary" noWrap>
-              {summary}
-            </Typography>
-          )}
+          <Title
+            title={"Demographic Rule"}
+            useSeparator={false}
+            subTitle={
+              !expanded && (
+                <Typography variant="body1" color="text.secondary" noWrap>
+                  {summary}
+                </Typography>
+              )
+            }
+          />
         </Stack>
 
         <Stack direction="row" alignItems="center" spacing={0.5}>
@@ -91,14 +85,6 @@ const DemographicsPanel = () => {
       </Stack>
 
       <Collapse in={expanded}>
-        <Divider sx={{ mb: 1 }} />
-
-        {!hasBeenConfigured && (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-            Set your demographic criteria below. Each category defaults to Any.
-          </Typography>
-        )}
-
         <DemographicAgeSection />
 
         <DemographicCheckboxSection
@@ -109,16 +95,6 @@ const DemographicsPanel = () => {
           onClear={clearSex}
           note={SEX_GUIDANCE}
         />
-
-        {SHOW_RACE && (
-          <DemographicConceptSection
-            label="Race"
-            domain={OmopTableName.Race}
-            concepts={race}
-            onToggle={toggleRace}
-            onClear={clearRace}
-          />
-        )}
       </Collapse>
     </Box>
   );

--- a/src/modules/DemographicsPanel/DemographicsPanel.tsx
+++ b/src/modules/DemographicsPanel/DemographicsPanel.tsx
@@ -13,8 +13,10 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 import AccordionExpandIcon from "@/components/AccordionExpandIcon";
 import { OmopTableName } from "@/types/omop";
+import { SEX_CONCEPTS, SEX_GUIDANCE } from "@/config/demographics";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import DemographicAgeSection from "./DemographicAgeSection";
+import DemographicCheckboxSection from "./DemographicCheckboxSection";
 import DemographicConceptSection from "./DemographicConceptSection";
 import { formatAgeSummary, formatConceptCountSummary } from "./summary";
 
@@ -99,12 +101,13 @@ const DemographicsPanel = () => {
 
         <DemographicAgeSection />
 
-        <DemographicConceptSection
+        <DemographicCheckboxSection
           label="Sex"
-          domain={OmopTableName.Gender}
-          concepts={sex}
+          options={SEX_CONCEPTS}
+          selected={sex}
           onToggle={toggleSex}
           onClear={clearSex}
+          note={SEX_GUIDANCE}
         />
 
         {SHOW_RACE && (


### PR DESCRIPTION
> **🤖 AI assistance disclosure:** This change was implemented with the help of Claude (Claude Code). All code has been reviewed by the author before submission.

## Summary

**Stack 4 of 4 for DP-857 (Demographics Panel).** Replaces the term-search UI for **Sex** with a fixed list of checkboxes, matching the agreed design.

- Sex is now a set of **`SquareCheckbox`es** — one per configured option — instead of a concept term search.
- The shown options are a **curated `concept_id` / `name` config** (`src/config/demographics.ts`, `SEX_CONCEPTS`), so which values appear is decided by hand for now. A code note flags that this could be sourced from an **API endpoint** in future, and that the `concept_id`s should be confirmed against the OMOP vocabulary in use.
- Adds a short guidance note under the checkboxes.
- Toggling a checkbox adds/removes the corresponding `Concept` in the demographics store exactly as before, so the submitted `demographics.sex` payload is unchanged in shape.

## Jira

https://hdruk.atlassian.net/browse/DP-857

## PR Type

- [x] `feat`

## PR Title Check

`feat(DP-857): configurable checkbox Sex selector in demographics panel`

## Changes Included

- [x] UI changes
- [x] Config (`src/config/demographics.ts`)
- [x] Test updates (`src/config/demographics.test.ts`)

Key files:
- `src/config/demographics.ts` — `SEX_CONCEPTS` (curated options), `SEX_GUIDANCE` note, `demographicOptionToConcept` helper.
- `src/modules/DemographicsPanel/DemographicCheckboxSection.tsx` — renders the fixed options as `SquareCheckbox`es + note.
- `src/modules/DemographicsPanel/DemographicsPanel.tsx` — Sex now uses the checkbox section (term-search `DemographicConceptSection` retained for the hidden Race scaffold).

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes (config helper test added)
- [ ] `npm run build` — pre-existing test-file type-check collision only (see Stack 1 note); non-test source clean.

## Coding Conventions Checklist

- [x] Uses `<SquareCheckbox>` per project convention (not raw MUI `<Checkbox>`)
- [x] Config centralised under `src/config`
- [x] `@/` imports, PascalCase component

## Risk and Rollback

- Risk level: low (self-contained UI swap for one section)
- Main risk areas: the curated `concept_id`s must match the vocabulary; confirm before relying on results
- Rollback plan: revert PR to restore the term-search Sex selector.

## Notes for Reviewers

Depends on Stacks 1–3. Please confirm the default `SEX_CONCEPTS` ids/names are the ones we want to surface (Female 8532, Male 8507, No matching concept 0, Unknown 8551) — they're intended to be edited freely.
