### PR TITLE
feat(DP-857): demographic subject in query preview text

### DIFF
--- a/src/components/CohortQueryPreview/CohortQueryPreview.tsx
+++ b/src/components/CohortQueryPreview/CohortQueryPreview.tsx
@@ -6,12 +6,30 @@ import CohortErrors from "@/modules/CohortErrors";
 import SubmitQueryButton from "@/components/SubmitQueryButton";
 
 import useQueryBuilder from "@/hooks/useQueryBuilder";
+import useFeatures from "@/hooks/useFeatures";
+import {
+  applyDemographicSubject,
+  formatDemographicSubject,
+} from "@/utils/demographicsText";
 import ClearQueryButton from "@/components/ClearQueryButton";
 import ShowJsonButton from "@/components/ShowJsonButton";
 
 const CohortQueryPreview = () => {
   const warnings = useQueryBuilder((qb) => qb.queryBuilderJson.warnings ?? []);
   const queryAsText = useQueryBuilder((qb) => qb.queryAsText);
+  const demographics = useQueryBuilder(
+    (qb) => qb.queryBuilderJson.demographics,
+  );
+
+  const { queryBuilderUseDemographicRule } = useFeatures();
+
+  const subject =
+    queryBuilderUseDemographicRule && demographics
+      ? formatDemographicSubject(demographics.age, demographics.sex)
+      : null;
+  const previewText = subject
+    ? applyDemographicSubject(queryAsText, subject)
+    : queryAsText;
 
   return (
     <Stack
@@ -23,7 +41,7 @@ const CohortQueryPreview = () => {
       width="100%"
     >
       <Stack>
-        <Typography>{queryAsText}</Typography>
+        <Typography>{previewText}</Typography>
         <CohortErrors />
       </Stack>
       <Stack gap={1} direction={"row"}>

--- a/src/utils/demographicsText.test.ts
+++ b/src/utils/demographicsText.test.ts
@@ -1,0 +1,67 @@
+import { Concept } from "@/types/api";
+import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
+import {
+  applyDemographicSubject,
+  formatDemographicSubject,
+} from "@/utils/demographicsText";
+
+const concept = (concept_id: number, name: string): Concept =>
+  ({ concept_id, name, category: "Gender" }) as Concept;
+
+const male = concept(8507, "Male");
+const female = concept(8532, "Female");
+
+describe("formatDemographicSubject", () => {
+  it("returns null when nothing is set", () => {
+    expect(formatDemographicSubject(null, [])).toBeNull();
+    expect(
+      formatDemographicSubject([MIN_AGE_FILTER, MAX_AGE_FILTER], []),
+    ).toBeNull();
+  });
+
+  it("pluralises a single sex", () => {
+    expect(formatDemographicSubject(null, [male])).toBe("Males");
+  });
+
+  it("joins multiple sexes with 'or'", () => {
+    expect(formatDemographicSubject(null, [female, male])).toBe(
+      "Females or Males",
+    );
+  });
+
+  it("phrases age only against 'People'", () => {
+    expect(formatDemographicSubject([85, MAX_AGE_FILTER], [])).toBe(
+      "People over 85",
+    );
+    expect(formatDemographicSubject([MIN_AGE_FILTER, 40], [])).toBe(
+      "People under 40",
+    );
+    expect(formatDemographicSubject([18, 65], [])).toBe(
+      "People between 18 and 65",
+    );
+  });
+
+  it("combines sex and age", () => {
+    expect(formatDemographicSubject([85, MAX_AGE_FILTER], [male])).toBe(
+      "Males over 85",
+    );
+  });
+});
+
+describe("applyDemographicSubject", () => {
+  it("replaces the leading People noun", () => {
+    expect(
+      applyDemographicSubject("People who were diagnosed with X", "Males over 85"),
+    ).toBe("Males over 85 who were diagnosed with X");
+  });
+
+  it("returns the subject alone for empty query text", () => {
+    expect(applyDemographicSubject("", "Males over 85")).toBe("Males over 85");
+  });
+
+  it("leaves text unchanged when it does not start with People", () => {
+    expect(applyDemographicSubject("Something else", "Males")).toBe(
+      "Something else",
+    );
+  });
+});

--- a/src/utils/demographicsText.ts
+++ b/src/utils/demographicsText.ts
@@ -1,0 +1,55 @@
+import { Concept } from "@/types/api";
+import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
+import { PREVIEW_SUBJECT_NOUN } from "@/utils/queryBuilder";
+
+const pluralizeSex = (name: string): string =>
+  name.endsWith("s") ? name : `${name}s`;
+
+const formatSexNoun = (sex: Concept[]): string | null => {
+  if (sex.length === 0) return null;
+  return sex.map((c) => pluralizeSex(c.name)).join(" or ");
+};
+
+const formatAgePhrase = (age: [number, number] | null): string | null => {
+  if (!age) return null;
+  const [min, max] = age;
+  const noLower = min <= MIN_AGE_FILTER;
+  const noUpper = max >= MAX_AGE_FILTER;
+
+  if (noLower && noUpper) return null;
+  if (!noLower && noUpper) return `over ${min}`;
+  if (noLower && !noUpper) return `under ${max}`;
+  return `between ${min} and ${max}`;
+};
+
+/**
+ * Builds a demographic subject noun-phrase for the query preview, e.g.
+ * "Males over 85". Returns null when neither sex nor a bounded age is set.
+ */
+export const formatDemographicSubject = (
+  age: [number, number] | null,
+  sex: Concept[],
+): string | null => {
+  const noun = formatSexNoun(sex);
+  const agePhrase = formatAgePhrase(age);
+
+  if (noun && agePhrase) return `${noun} ${agePhrase}`;
+  if (noun) return noun;
+  if (agePhrase) return `${PREVIEW_SUBJECT_NOUN} ${agePhrase}`;
+  return null;
+};
+
+/**
+ * Splices a demographic subject into a preview sentence by replacing the
+ * leading "People" noun (e.g. "People who ..." -> "Males over 85 who ...").
+ */
+export const applyDemographicSubject = (
+  queryText: string,
+  subject: string,
+): string => {
+  if (queryText.length === 0) return subject;
+  if (queryText.startsWith(`${PREVIEW_SUBJECT_NOUN} `)) {
+    return `${subject}${queryText.slice(PREVIEW_SUBJECT_NOUN.length)}`;
+  }
+  return queryText;
+};

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -14,12 +14,14 @@ import { getDomainPhrase } from "./omop";
 
 type Piece = { verb?: string | null; text: string };
 
+export const PREVIEW_SUBJECT_NOUN = "People";
+
 const queryToText = (
   node: RuleGroupType,
   options?: { includeBrackets?: boolean },
 ) => {
   const includeBrackets = options?.includeBrackets ?? false;
-  const subject = "People who";
+  const subject = `${PREVIEW_SUBJECT_NOUN} who`;
 
   const getVerb = (category: string, exclude = false): string => {
     const domain = getDomainPhrase(category);


### PR DESCRIPTION
> **🤖 AI assistance disclosure:** This change was implemented with the help of Claude (Claude Code). All code has been reviewed by the author before submission.

## Summary

**Stack 5 of 5 for DP-857 (Demographics Panel).** Folds the demographic block into the **query preview text**.

- When `query-builder-use-demographic-rule` is on and demographics are set, the "Query / Preview" sentence reads e.g. **"Males over 85 who were diagnosed with X"** — the demographic subject replaces the leading "People".
- **Preview display only**: the stored `queryAsText` and the natural-language search input stay rule-tree-only, so demographics never round-trip through the NL parser.
- Reads demographics from `queryBuilderJson.demographics` (single source of truth from Stack 1).

## Jira

https://hdruk.atlassian.net/browse/DP-857

## PR Type

- [x] `feat`

## PR Title Check

`feat(DP-857): demographic subject in query preview text`

## Changes Included

- [x] UI changes (`CohortQueryPreview`)
- [x] Test updates (`demographicsText.test.ts`)

Key files:
- `src/utils/demographicsText.ts` (+ test) — `formatDemographicSubject(age, sex)` (pluralised sex noun + age phrase, e.g. "Males over 85") and `applyDemographicSubject` (splices the subject into the leading noun).
- `src/utils/queryBuilder.ts` — exports `PREVIEW_SUBJECT_NOUN` ("People") so the splice stays in sync with the generator.
- `src/components/CohortQueryPreview/CohortQueryPreview.tsx` — derives the subject from `queryBuilderJson.demographics` and the flag; renders the spliced text.

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes (formatter/splice tests added)
- [ ] `npm run build` — pre-existing test-file type-check collision only (see Stack 1 note); non-test source clean.

## Out of scope

- Saved-query text (`QueriesTable` / `QueryResultsPage`) — a follow-up.
- Changing `queryAsText` / the NL round-trip (kept rule-tree-only by decision).
- Refined pluralisation for awkward names ("No matching concept"); simple `+s` for now.

## Notes for Reviewers

Depends on Stacks 1–4. With the flag on: add a demographic rule, set Sex=Male and Age min 85 → preview reads "Males over 85 who …"; clear demographics → reverts to "People who …"; the NL search input box is unchanged.
