### PR TITLE
fix(DP-1040): UI improvements for term directory 2

### DIFF
--- a/cypress/e2e/term-directory/term-directory.cy.ts
+++ b/cypress/e2e/term-directory/term-directory.cy.ts
@@ -9,7 +9,7 @@ describe("Term Directory", () => {
   });
 
   it("shows the correct table columns", () => {
-    cy.contains("OMOP ID").should("be.visible");
+    cy.contains("OMOP Concept ID").should("be.visible");
     cy.contains("Term Name").should("be.visible");
     cy.contains("Count").should("be.visible");
     cy.contains("Associated Collections").should("be.visible");

--- a/src/components/TopMenu/TopMenu.tsx
+++ b/src/components/TopMenu/TopMenu.tsx
@@ -120,9 +120,15 @@ export default function TopMenu() {
         value={currentTabValue}
         sx={{ height: "auto" }}
         tabSx={(theme) => ({
+          "& .MuiSvgIcon-root": {
+            color: theme.palette.tooltip?.main,
+          },
           "&.Mui-selected": {
             bgcolor: theme.palette.secondary.main,
             color: theme.palette.secondary.contrastText,
+            "& .MuiSvgIcon-root": {
+              color: "inherit",
+            },
           },
         })}
         tabHeaderSx={(theme) => ({

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -22,7 +22,7 @@ describe("TermDirectory", () => {
     renderComponent(paginateData({ data: mockTermDirectoryEntries }));
 
     const columns = [
-      "OMOP ID",
+      "OMOP Concept ID",
       "Term Name",
       "Domain",
       "Count",

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -75,10 +75,10 @@ describe("TermDirectory", () => {
     renderComponent(paginateData({ data: mockTermDirectoryEntries }));
 
     expect(
-      screen.getByRole("button", { name: "Copy OMOP ID 201826" }),
+      screen.getByRole("button", { name: "Copy OMOP Concept ID 201826" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Copy OMOP ID 4329847" }),
+      screen.getByRole("button", { name: "Copy OMOP Concept ID 4329847" }),
     ).toBeInTheDocument();
   });
 
@@ -88,7 +88,7 @@ describe("TermDirectory", () => {
     const writeText = jest.spyOn(navigator.clipboard, "writeText");
 
     await user.click(
-      screen.getByRole("button", { name: "Copy OMOP ID 201826" }),
+      screen.getByRole("button", { name: "Copy OMOP Concept ID 201826" }),
     );
 
     expect(writeText).toHaveBeenCalledWith("201826");

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -21,7 +21,7 @@ const TermDirectory = ({
     () => [
       {
         id: "concept_id",
-        header: "OMOP ID",
+        header: "OMOP Concept ID",
         accessorFn: (row) => row.concept_id,
         Cell: ({ cell }) => (
           <Stack direction="row" alignItems="center">
@@ -29,7 +29,7 @@ const TermDirectory = ({
             <CopyableTextButton
               text={String(cell.getValue<number>())}
               size="small"
-              ariaLabel={`Copy OMOP ID ${cell.getValue<number>()}`}
+              ariaLabel={`Copy OMOP Concept ID ${cell.getValue<number>()}`}
             />
           </Stack>
         ),
@@ -81,6 +81,7 @@ const TermDirectory = ({
     getRowId: (row) => String(row?.concept_id),
     enableStickyHeader: true,
     enableSorting: false,
+    enableRowSelection: false,
   });
 
   return (
@@ -97,7 +98,9 @@ const TermDirectory = ({
         "& > .MuiGrid-container": {
           bgcolor: "table.main",
           p: 1,
-          borderRadius: 1,
+        },
+        "& .MuiPaper-root": {
+          borderRadius: 0,
         },
       }}
     />


### PR DESCRIPTION
## Summary

Change 1 - Removed default checkboxes from table (not used for anything at the moment, and for the Query Cart feature there is a different design anyway)

Change 2 - Changed color of the icon tab for Term Directory (and also Help) to the original blue rather than gray

Change 3 - Renamed 'OMOP ID' table heading to 'OMOP Concept ID'

Change 4 - Match non-rounded corners of search bar bg and table headers with Figma

## Jira

https://hdruk.atlassian.net/browse/DP-1040

## PR Type

- [ ] `feat`
- [X] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [X] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [X] `npm run lint` passes
- [X] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<!-- For UI work, add before/after screenshots or short video. -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
