### PR TITLE
fix(DP-1057): stop search overlay flashing open on first click after load

### DIFF
--- a/src/components/CohortQueryInput/CohortQueryInput.test.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.test.tsx
@@ -57,7 +57,10 @@ const covidAndCancerQuery = createRuleGroup([covidRule, andRule, cancerRule]);
 
 const covidOrCancerQuery = createRuleGroup([covidRule, orRule, cancerRule]);
 
-const renderComponent = ({ queryBuilderJson = createRuleGroup([]) } = {}, extraOverrides: Record<string, unknown> = {}) => {
+const renderComponent = (
+  { queryBuilderJson = createRuleGroup([]), autoFocus = false } = {},
+  extraOverrides: Record<string, unknown> = {},
+) => {
   return render(
     <MockCohortDiscoveryServiceStore
       overrides={{
@@ -73,7 +76,7 @@ const renderComponent = ({ queryBuilderJson = createRuleGroup([]) } = {}, extraO
         },
       }}
     >
-      <CohortQueryInput queries={[]} />
+      <CohortQueryInput queries={[]} autoFocus={autoFocus} />
     </MockCohortDiscoveryServiceStore>,
   );
 };
@@ -159,6 +162,32 @@ describe("CohortQueryInput", () => {
     ).toBeInTheDocument();
 
     expect(await screen.findByText("Query Examples")).toBeInTheDocument();
+  });
+
+  it("does not open the search overlay when a pristine autofocused input is blurred (DP-1057)", async () => {
+    const user = userEvent.setup();
+
+    renderComponent({ autoFocus: true });
+
+    const input = getSearchInput();
+
+    // autoFocus should acquire focus, but the overlay must stay hidden
+    await waitFor(() => expect(input).toHaveFocus());
+
+    expect(
+      screen.queryByTestId("search-overlay-paper"),
+    ).not.toBeInTheDocument();
+
+    // clicking anywhere off the input blurs it. The old bug cleared
+    // suppressInitialExamples synchronously while deferring the openSearchOverlap
+    // reset by 150ms, leaving a window where the overlay flashed open. Assert
+    // immediately after the blur (inside that window) that it never appears.
+    await user.click(document.body);
+
+    expect(
+      screen.queryByTestId("search-overlay-paper"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Query Examples")).not.toBeInTheDocument();
   });
 
   it("hides the examples once 3+ characters are typed and shows them again below 3", async () => {

--- a/src/components/CohortQueryInput/CohortQueryInput.tsx
+++ b/src/components/CohortQueryInput/CohortQueryInput.tsx
@@ -85,6 +85,7 @@ const CohortQueryInput = ({
   const programmaticValueRef = useRef<string | null>(null);
   const lastSyncedQueryAsText = useRef<string | null>(null);
   const anchorRef = useRef<HTMLDivElement | null>(null);
+  const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const {
     handleSubmit: handleSubmitSearch,
@@ -124,6 +125,15 @@ const CohortQueryInput = ({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setQueryMode((current) => (current === null ? current : null));
   }, [rulesKey]);
+
+  useEffect(
+    () => () => {
+      if (blurTimeoutRef.current) {
+        clearTimeout(blurTimeoutRef.current);
+      }
+    },
+    [],
+  );
 
   const resetQuery = useCallback(() => {
     clearFormErrors();
@@ -452,14 +462,25 @@ const CohortQueryInput = ({
                   endIcon={<EndIcon sx={endIconSx} />}
                   onClickEndAdornment={onSubmit}
                   onFocus={() => {
-                    if (!showChoicePrompt && !isAppendMode) {
+                    if (blurTimeoutRef.current) {
+                      clearTimeout(blurTimeoutRef.current);
+                      blurTimeoutRef.current = null;
+                    }
+                    if (
+                      !showChoicePrompt &&
+                      !isAppendMode &&
+                      !suppressInitialExamples
+                    ) {
                       setOpenSearchOverlap(true);
                     }
                   }}
                   onBlur={() => {
                     field.onBlur();
                     setSuppressInitialExamples(false);
-                    setTimeout(() => setOpenSearchOverlap(false), 150);
+                    blurTimeoutRef.current = setTimeout(() => {
+                      setOpenSearchOverlap(false);
+                      blurTimeoutRef.current = null;
+                    }, 150);
                   }}
                   onChange={(e) => {
                     programmaticValueRef.current = null;


### PR DESCRIPTION
> ⚠️ **AI disclaimer:** AI (Claude) was used to help investigate the root cause, implement this fix, and author the regression test and this PR description. All changes have been reviewed by the author.

## Summary

Fixes an intermittent bug where the `CohortQueryInput` search overlay would flash open when the user clicked **anywhere** on the page shortly after first load.

The overlay's visibility (`showSearchOverlay`) depends on two pieces of state that were being cleared **asymmetrically** in the input's `onBlur`:

- `setSuppressInitialExamples(false)` — applied **synchronously**
- `setOpenSearchOverlap(false)` — deferred by a **150ms `setTimeout`**

On first load, `autoFocus` fires `onFocus`, which armed `openSearchOverlap = true` (kept hidden only by `suppressInitialExamples`). The first click anywhere blurred the auto-focused input, clearing `suppressInitialExamples` immediately while `openSearchOverlap` stayed `true` for ~150ms — opening a window where every gate in `showSearchOverlay` was true and the overlay flashed open.

It felt intermittent because the flash is only ~150ms and browsers suppress `autoFocus` on background/unfocused tabs. In practice the fragile state was armed on **every** dashboard load (`autoFocus` is hard-coded `true` at the call site).

**Fix:** guard `onFocus` with `!suppressInitialExamples` so the pristine autofocus never arms `openSearchOverlap` — removing the state the blur race exposed. Additionally, the deferred blur timeout is now captured in a ref and cleared on refocus and on unmount, preventing a stale close firing after a fast re-focus and avoiding a set-state-after-unmount.

## Jira

https://hdruk.atlassian.net/browse/DP-1057

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `fix(DP-1057): stop search overlay flashing open on first click after load`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [x] State management changes (hooks/store)
- [x] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [x] `npm run test` passes (186/186)
- [x] `npm run build` passes

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts` (n/a — no routing changes)
- [x] API calls follow existing patterns (n/a — no API changes)
- [x] Side-effectful endpoints are not cached unintentionally (n/a)
- [x] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

N/A — the fix removes a transient (~150ms) visual glitch. Behaviour is verified by an automated regression test instead:

- The new test (`does not open the search overlay when a pristine autofocused input is blurred (DP-1057)`) renders with `autoFocus`, waits for focus, clicks away, and asserts the overlay never appears within the race window.
- Confirmed the test **fails** against the pre-fix code (overlay found in the DOM) and **passes** with the fix applied.

## Risk and Rollback

- Risk level: **low**
- Main risk areas:
  - Search overlay open/close behaviour in the cohort query builder (focus/blur/typing flows)
- Rollback plan:
  - Revert this PR — change is isolated to `CohortQueryInput.tsx` (focus/blur handlers + a cleanup effect)

## Notes for Reviewers

- The core fix is the single `!suppressInitialExamples` condition added to `onFocus`. The `blurTimeoutRef` capture + `clearTimeout` (on refocus and via an unmount effect) is a small hardening for the pre-existing un-cleared `setTimeout`.
- `renderComponent` in the test file was extended to forward `autoFocus` — previously it never passed the prop, so `suppressInitialExamples`'s autofocus path was entirely untested.
