### PR TITLE
fix(DP-1007): fix paginated tables not resetting to page 1 when a filter or search changes

### DIFF
--- a/src/hooks/usePaginatedTable.ts
+++ b/src/hooks/usePaginatedTable.ts
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   MRT_ColumnDef,
   MRT_RowData,
   MRT_TableOptions,
   MRT_SortingState,
+  MRT_PaginationState,
+  MRT_Updater,
 } from "material-react-table";
 import { useTable } from "./useTable";
 import { buildRowsPerPageOptions } from "@/utils/pagination";
@@ -51,10 +53,26 @@ export function usePaginatedTable<TData extends MRT_RowData>({
   );
   const rowsPerPageOptions = buildRowsPerPageOptions(resolvedPerPageDefault);
 
-  const [pagination, setPagination] = useState({
-    pageIndex: page - 1,
-    pageSize: perPage,
-  });
+  const pagination = useMemo(
+    () => ({ pageIndex: page - 1, pageSize: perPage }),
+    [page, perPage],
+  );
+
+  const handlePaginationChange = (
+    updaterOrValue: MRT_Updater<MRT_PaginationState>,
+  ) => {
+    const nextPagination =
+      typeof updaterOrValue === "function"
+        ? updaterOrValue(pagination)
+        : updaterOrValue;
+
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.set(pageParam, String(nextPagination.pageIndex + 1));
+    params.set(perPageParam, String(nextPagination.pageSize));
+
+    router.replace(`?${params.toString()}`);
+  };
 
   const [sorting, setSorting] = useState<MRT_SortingState>([]);
 
@@ -70,30 +88,6 @@ export function usePaginatedTable<TData extends MRT_RowData>({
   }, [sorting, router, searchParams]);
   */
 
-  useEffect(() => {
-    const currentPage = (pagination.pageIndex + 1).toString();
-    const currentPerPage = pagination.pageSize.toString();
-
-    if (
-      currentPage === searchParams.get(pageParam) &&
-      currentPerPage === searchParams.get(perPageParam)
-    )
-      return;
-
-    const params = new URLSearchParams(searchParams.toString());
-    params.set(pageParam, currentPage);
-    params.set(perPageParam, currentPerPage);
-
-    router.replace(`?${params.toString()}`);
-  }, [
-    pagination.pageIndex,
-    pagination.pageSize,
-    router,
-    searchParams,
-    pageParam,
-    perPageParam,
-  ]);
-
   const firstRowId = getRowId(data?.[0]);
   const expanded = useMemo(() => {
     return firstRowId && expandFirstRow ? { [firstRowId]: true } : {};
@@ -107,7 +101,7 @@ export function usePaginatedTable<TData extends MRT_RowData>({
     enablePagination: true,
     manualPagination: true,
     enableSorting: true,
-    onPaginationChange: setPagination,
+    onPaginationChange: handlePaginationChange,
     onSortingChange: setSorting,
     initialState: {
       ...initialState,

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -8,6 +8,14 @@ import { mockTermDirectoryEntries } from "@/actions/termDirectory/__mocks__/getT
 import { paginateData } from "@/utils/mock";
 import { TermDirectoryEntry, Paginated } from "@/types/api";
 
+let mockSearchParams = new URLSearchParams("page=1&per_page=5");
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => "/term-directory",
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
 const renderComponent = (entries: Paginated<TermDirectoryEntry>) =>
   render(
     <DefaultProvider>
@@ -107,5 +115,29 @@ describe("TermDirectory", () => {
       name: /Myocardial infarction/i,
     });
     expect(within(secondRow).getByText("Observation")).toBeInTheDocument();
+  });
+
+  it("takes the current page from the URL, so a filter resetting to page 1 is not overridden by the table", () => {
+    const entries = {
+      ...paginateData({ data: mockTermDirectoryEntries, perPage: 5 }),
+      total: 100,
+    };
+
+    mockSearchParams = new URLSearchParams("page=3&per_page=5");
+    const { rerender } = renderComponent(entries);
+
+    expect(screen.getByText("11-15 of 100")).toBeInTheDocument();
+
+    // a filter (eg the domain tabs) puts the user back on page 1
+    mockSearchParams = new URLSearchParams("page=1&per_page=5");
+    rerender(
+      <DefaultProvider>
+        <NotifyProvider>
+          <TermDirectory entries={entries} />
+        </NotifyProvider>
+      </DefaultProvider>,
+    );
+
+    expect(screen.getByText("1-5 of 100")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

This fixes a bug where selecting a filter in the Term Directory was supposed to put you back on page 1, but it didn't.

The domain/collection filters both set the page back to 1 when they are applied, but the usePaginatedTable hook kept its own internal copy of the current page in useState, and a useEffect in there put that outdated copy back into the URL straight after. The page now comes from the URL only, so there's nothing left to overwrite it.

## Jira

https://hdruk.atlassian.net/browse/DP-1007

## PR Type

- [ ] `feat`
- [X] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [X] State management changes (hooks/store)
- [X] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [X] `npm run lint` passes
- [X] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

### Before:

https://github.com/user-attachments/assets/76aebb7b-2743-4755-9778-2f2de0e4bbfb

### After:

https://github.com/user-attachments/assets/8f26659d-8b01-466b-ac64-1673717bb72a

### Tests:

```
 PASS  src/modules/TermDirectory/TermDirectory.test.tsx (19.936 s)
  TermDirectory
    ✓ renders the correct column headers (160 ms)
    ✓ renders a row per entry with its OMOP id, name and collection count (72 ms)
    ✓ renders the count, formatted with thousands separators for readability (31 ms)
    ✓ shows an empty message when no terms are returned (12 ms)
    ✓ renders a search box so users can filter the directory (35 ms)
    ✓ shows a copy OMOP ID action on each row (47 ms)
    ✓ copies the raw OMOP id to the clipboard and confirms, so it can be pasted into rule search (139 ms)
    ✓ renders each term's domain (65 ms)

    vvv NEW TEST vvv
    ✓ takes the current page from the URL, so a filter resetting to page 1 is not overridden by the table (41 ms)
```

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
