### PR TITLE
feat(DP-1063): show location in query preview

### DIFF
--- a/src/components/CohortQueryPreview/CohortQueryPreview.tsx
+++ b/src/components/CohortQueryPreview/CohortQueryPreview.tsx
@@ -21,11 +21,15 @@ const CohortQueryPreview = () => {
     (qb) => qb.queryBuilderJson.demographics,
   );
 
-  const { queryBuilderUseDemographicRule } = useFeatures();
+  const { queryBuilderUseDemographicRule, queryBuilderUseLocation } =
+    useFeatures();
 
+  const location = queryBuilderUseLocation
+    ? (demographics?.location ?? null)
+    : null;
   const subject =
     queryBuilderUseDemographicRule && demographics
-      ? formatDemographicSubject(demographics.age, demographics.sex)
+      ? formatDemographicSubject(demographics.age, demographics.sex, location)
       : null;
   const previewText = subject
     ? applyDemographicSubject(queryAsText, subject)

--- a/src/utils/demographicsText.test.ts
+++ b/src/utils/demographicsText.test.ts
@@ -46,6 +46,38 @@ describe("formatDemographicSubject", () => {
       "Males over 85",
     );
   });
+
+  it("phrases location only against 'People'", () => {
+    expect(
+      formatDemographicSubject(null, [], {
+        lat: 51.5,
+        lon: -0.1,
+        radius: 50000,
+        address: "London",
+      }),
+    ).toBe("People living within 50.0 km of London");
+  });
+
+  it("falls back to coordinates when the location has no address", () => {
+    expect(
+      formatDemographicSubject(null, [], {
+        lat: 51.5,
+        lon: -0.1,
+        radius: 5000,
+      }),
+    ).toBe("People living within 5.0 km of (51.5000, -0.1000)");
+  });
+
+  it("combines sex, age and location", () => {
+    expect(
+      formatDemographicSubject([85, MAX_AGE_FILTER], [male], {
+        lat: 51.5,
+        lon: -0.1,
+        radius: 50000,
+        address: "London",
+      }),
+    ).toBe("Males over 85 living within 50.0 km of London");
+  });
 });
 
 describe("applyDemographicSubject", () => {

--- a/src/utils/demographicsText.ts
+++ b/src/utils/demographicsText.ts
@@ -1,6 +1,8 @@
 import { Concept } from "@/types/api";
+import { GeoRadiusLocation } from "@/types/rules";
 import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
 import { PREVIEW_SUBJECT_NOUN } from "@/utils/queryBuilder";
+import { formatRadius } from "@/components/GeoMap";
 
 const pluralizeSex = (name: string): string =>
   name.endsWith("s") ? name : `${name}s`;
@@ -22,21 +24,35 @@ const formatAgePhrase = (age: [number, number] | null): string | null => {
   return `between ${min} and ${max}`;
 };
 
+const formatLocationPhrase = (
+  location: GeoRadiusLocation | null,
+): string | null => {
+  if (!location) return null;
+  const { lat, lon, radius, address } = location;
+  const place = address ?? `(${lat.toFixed(4)}, ${lon.toFixed(4)})`;
+  return `living within ${formatRadius(radius)} of ${place}`;
+};
+
 /**
  * Builds a demographic subject noun-phrase for the query preview, e.g.
- * "Males over 85". Returns null when neither sex nor a bounded age is set.
+ * "Males over 85 living within 5.0 km of London". Returns null when none of
+ * sex, a bounded age, or a location is set.
  */
 export const formatDemographicSubject = (
   age: [number, number] | null,
   sex: Concept[],
+  location: GeoRadiusLocation | null = null,
 ): string | null => {
   const noun = formatSexNoun(sex);
   const agePhrase = formatAgePhrase(age);
+  const locationPhrase = formatLocationPhrase(location);
 
-  if (noun && agePhrase) return `${noun} ${agePhrase}`;
-  if (noun) return noun;
-  if (agePhrase) return `${PREVIEW_SUBJECT_NOUN} ${agePhrase}`;
-  return null;
+  if (!noun && !agePhrase && !locationPhrase) return null;
+
+  const parts = [noun ?? PREVIEW_SUBJECT_NOUN];
+  if (agePhrase) parts.push(agePhrase);
+  if (locationPhrase) parts.push(locationPhrase);
+  return parts.join(" ");
 };
 
 /**


### PR DESCRIPTION
> _Disclaimer: AI (Claude) was used to assist with implementing and documenting the changes in this PR._

## Summary

Makes the chosen patient **Location** appear in the Query Builder's natural-language **preview**
sentence. Building on the Location demographic filter (DP-1061), the preview now reads e.g.
"People living within 5.0 km of London who …", combining naturally with the existing age/sex
subject ("Males over 85 living within 5.0 km of London …").

## Jira

https://hdruk.atlassian.net/browse/DP-1063

## PR Type

- [x] `feat`

## Changes Included

- [x] UI changes — preview sentence now includes the location clause
- [x] Test updates

### Key changes
- `src/utils/demographicsText.ts` — new internal `formatLocationPhrase` producing
  `living within <radius> of <address | (lat, lon)>`; `formatDemographicSubject` gains an optional
  third `location` arg and folds the clause into the subject phrase (existing 2-arg callers/tests
  unaffected).
- `src/components/CohortQueryPreview/CohortQueryPreview.tsx` — passes `demographics.location` to
  `formatDemographicSubject`, gated by the `query-builder-use-location` flag (consistent with the
  panel). `queryToText`/`queryAsText` are untouched — they never handle demographics.
- `src/utils/demographicsText.test.ts` — new cases for location-only, coordinate fallback (no
  address), and combined sex + age + location.

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes (236 tests)
- [x] `npm run build` passes

## Risk and Rollback

- Risk level: **low** — text-only preview change, flag-gated by `query-builder-use-location`.
- Rollback: revert the PR; with the flag off there is no behavioural change.

## Notes for Reviewers

- Coordinate fallback uses `toFixed(4)`, mirroring the panel's `DemographicLocationSection`.
