### PR TITLE
fix(DP-1065): speed up admin collection fetching and narrow revalidation

### DIFF
--- a/src/actions/collection/updateCollectionWithConfig.ts
+++ b/src/actions/collection/updateCollectionWithConfig.ts
@@ -25,7 +25,7 @@ const updateCollectionWithConfig = async (
     `${API_ROUTES.collectionConfig}/${data.config.id}`,
     payloadConfig,
   );
-  if (refreshCache) await revalidateCollections(data.custodian.pid);
+  if (refreshCache) await revalidateCollections(data.custodian.pid, false);
   return data;
 };
 

--- a/src/app/(protected)/(admin)/admin/[tabId]/components/WorkgroupsTab.tsx
+++ b/src/app/(protected)/(admin)/admin/[tabId]/components/WorkgroupsTab.tsx
@@ -14,8 +14,10 @@ export const WorkgroupsSkeleton = () => (
 
 const WorkgroupsTab = async ({
   searchParams,
+  collectionsPromise,
 }: {
   searchParams: CollectionsSearchParams;
+  collectionsPromise?: ReturnType<typeof getAdminCollections>;
 }) => {
   const { page = 1, per_page = DEFAULT_PER_PAGE, ...rest } = searchParams ?? {};
 
@@ -25,7 +27,8 @@ const WorkgroupsTab = async ({
     ...rest,
   });
 
-  const { data: collections } = await getAdminCollections({ params });
+  const { data: collections } = await (collectionsPromise ??
+    getAdminCollections({ params }));
 
   return <WorkgroupsAdmin collections={collections} />;
 };

--- a/src/app/(protected)/(admin)/admin/[tabId]/page.tsx
+++ b/src/app/(protected)/(admin)/admin/[tabId]/page.tsx
@@ -12,6 +12,8 @@ import WorkgroupsTab, { WorkgroupsSkeleton } from "./components/WorkgroupsTab";
 import { SearchParams } from "@/types/api";
 import { isStandalone } from "@/utils/modes";
 import NetworksTab from "./components/NetworksTab";
+import getAdminCollections from "@/actions/collection/getAdminCollections";
+import { buildCollectionParams } from "@/utils/params";
 
 type Params = Promise<{ tabId: string }>;
 
@@ -26,6 +28,10 @@ const CustodianAdminPage = async ({
 }) => {
   const { tabId } = await params;
   const apiSearchParams = await searchParams;
+
+  const adminCollectionsPromise = getAdminCollections({
+    params: buildCollectionParams(apiSearchParams),
+  });
 
   const TABS = [
     ...(isStandalone(applicationMode)
@@ -48,7 +54,10 @@ const CustodianAdminPage = async ({
       href: routes.adminWorkgroups,
       page: (
         <Suspense fallback={<WorkgroupsSkeleton />}>
-          <WorkgroupsTab searchParams={apiSearchParams} />
+          <WorkgroupsTab
+            searchParams={apiSearchParams}
+            collectionsPromise={adminCollectionsPromise}
+          />
         </Suspense>
       ),
     },
@@ -58,7 +67,10 @@ const CustodianAdminPage = async ({
       href: routes.adminCollections,
       page: (
         <Suspense fallback={<CollectionsSkeleton />}>
-          <CollectionsTab searchParams={apiSearchParams} />
+          <CollectionsTab
+            searchParams={apiSearchParams}
+            collectionsPromise={adminCollectionsPromise}
+          />
         </Suspense>
       ),
     },

--- a/src/modules/CollectionsTab/CollectionsTab.tsx
+++ b/src/modules/CollectionsTab/CollectionsTab.tsx
@@ -15,19 +15,20 @@ export const CollectionsSkeleton = () => (
 const CollectionsTab = async ({
   searchParams,
   custodianPid,
+  collectionsPromise,
 }: {
   searchParams: CollectionsSearchParams;
   custodianPid?: string;
+  collectionsPromise?: ReturnType<typeof getAdminCollections>;
 }) => {
   const params = buildCollectionParams(searchParams);
 
   const isAdmin = !custodianPid;
 
-  const [{ data: collections }] = await Promise.all([
-    isAdmin
+  const { data: collections } = await (collectionsPromise ??
+    (isAdmin
       ? getAdminCollections({ params })
-      : getCustodianCollections(custodianPid, { params }),
-  ]);
+      : getCustodianCollections(custodianPid, { params })));
 
   return <CollectionsManagement isAdmin={isAdmin} collections={collections} />;
 };


### PR DESCRIPTION
> ⚠️ **Disclaimer:** AI (Claude Code) was used to assist with parts of these changes — including splitting these changes out of `feat/DP-1037` and drafting this description.

## Summary

Maintenance work to reduce slow admin collection fetching/caching. Two independent improvements:

1. **Shared collection fetch across admin tabs** — the admin page now issues a single `getAdminCollections` request and passes the same promise to both the Workgroups and Collections tabs, instead of each tab fetching the collections list independently.
2. **Narrower revalidation on config-only updates** — `updateCollectionWithConfig` now calls `revalidateCollections(pid, false)` so collection-host cache tags are no longer revalidated when only the collection config changed.

Split out of `feat/DP-1037` (DP-1037) so it can be reviewed independently.

## Jira

https://hdruk.atlassian.net/browse/DP-1065

## PR Type

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [x] `perf`

## PR Title Check

`fix(DP-1065): speed up admin collection fetching and narrow revalidation`

## Changes Included

- [ ] UI changes
- [x] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

### Detail

- **`src/app/(protected)/(admin)/admin/[tabId]/page.tsx`** — builds one `getAdminCollections` promise from `buildCollectionParams(apiSearchParams)` and passes it to both `WorkgroupsTab` and `CollectionsTab`.
- **`WorkgroupsTab.tsx` / `CollectionsTab.tsx`** — accept an optional `collectionsPromise` prop and await it when supplied, falling back to their own fetch otherwise.
- **`src/actions/collection/updateCollectionWithConfig.ts`** — passes `includeHosts = false` to `revalidateCollections` on config-only updates (the `includeHosts` parameter already exists on `dev`).

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [x] `npm run test` passes (39 suites, 220 tests)
- [ ] `npm run build` — full build type-check hits a pre-existing Jest/Vitest `expect` collision in test files, unrelated to this branch

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions
- [x] Imports follow existing ordering and alias usage (`@/`)
- [x] Routes built with helpers in `src/config/routes.ts`
- [x] API calls follow existing patterns (server actions, `apiGet/apiPost/...`)
- [x] Side-effectful endpoints not cached unintentionally
- [x] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

_No visible UI change — this is a data-loading/caching optimisation._

## Risk and Rollback

- Risk level: **low–medium**
- Main risk areas:
  - Admin Workgroups/Collections tabs now share one params set derived from `buildCollectionParams(apiSearchParams)`. `WorkgroupsTab`'s previous `per_page = DEFAULT_PER_PAGE` default is bypassed when the shared promise is used, so the request relies on the backend default page size — **confirm the backend default matches `DEFAULT_PER_PAGE`.**
  - The shared promise is created eagerly on the admin page, so the collections fetch fires even when a non-collection tab (e.g. Networks) is active.
  - Collection-config-only updates no longer revalidate collection-host cache tags — verify host lists still refresh where expected.
- Rollback plan:
  - Revert PR. Each change is independent; the revalidation change and the shared-promise change can be reverted separately if needed.

## Notes for Reviewers

- Consider whether the shared `adminCollectionsPromise` should only be created when the active tab actually needs collections, and/or attach a `.catch` to avoid an unhandled rejection if neither collection tab renders.
