### PR TITLE
fix(DP-1073): populate location/death collection toggles from fetched value

### DIFF
--- a/src/modules/UpdateCollection/UpdateCollection.tsx
+++ b/src/modules/UpdateCollection/UpdateCollection.tsx
@@ -62,6 +62,8 @@ const getDefaultValues = (collection: CollectionWithHosts | null) => {
         model_state: undefined,
         workgroups: [],
         is_synthetic: false,
+        location_enabled: false,
+        death_enabled: false,
       },
       config: {
         frequency_mode: Number(FrequencyMode.WEEKLY),
@@ -81,6 +83,8 @@ const getDefaultValues = (collection: CollectionWithHosts | null) => {
     model_state,
     workgroups,
     is_synthetic,
+    location_enabled,
+    death_enabled,
   } = collection;
   const [host] = hosts;
   return {
@@ -92,6 +96,8 @@ const getDefaultValues = (collection: CollectionWithHosts | null) => {
       model_state: model_state,
       workgroups: workgroups,
       is_synthetic: is_synthetic,
+      location_enabled: location_enabled ?? false,
+      death_enabled: death_enabled ?? false,
     },
     config: {
       frequency_mode: config.frequency_mode,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -179,6 +179,8 @@ export interface Collection extends WithTimestamps {
   custodian_id?: number;
   model_state: ModelState;
   is_synthetic?: boolean;
+  location_enabled?: boolean;
+  death_enabled?: boolean;
 }
 
 export interface CollectionConfig {


### PR DESCRIPTION
> 🤖   Claude was used in the diagnosis of this problem and writing the PR description

# Summary
- Populates the collection edit form's `location_enabled` / `death_enabled` toggles from the fetched collection, and adds those two fields to the `Collection` read-model type.
- Fixes the bug where toggling location/death enabled on a collection appeared not to persist — on save/refresh it always reverted to "Disabled".

**Why:** The toggles (`ToggleLocation`/`ToggleDeath`) register `collection.location_enabled` / `collection.death_enabled`, and the outbound `PUT` already sends them correctly. But:
1. The `Collection` read-model interface (`src/types/api.ts`) never declared `location_enabled`/`death_enabled`, so the fetched value wasn't modelled.
2. `getDefaultValues()` in `UpdateCollection.tsx` never populated them (unlike `is_synthetic`), so `Controller.field.value` was `undefined` on every mount.

As a result the toggle always rendered falsy, and the post-save `reset(getDefaultValues(collection))` wiped any in-session change back to `undefined` — indistinguishable from "the save didn't take". On a hard refresh, SSR fed the fresh collection through the same `getDefaultValues`, again dropping the fields.

This change makes the form read the real persisted values on load/reset/refresh. The write path was already correct, so no API change is required (see DP-1072 for the separate BE-only fix).

# Type Of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Chore

# Testing
- [x] `eslint` on changed files (clean)
- [x] `tsc --noEmit` — no new errors introduced (pre-existing errors in `__mocks__`/`*.test.tsx` only, present on `origin/dev`)
- [ ] Manual: toggle location/death on a collection, save, refresh — value now persists visually (to verify on dev)
- [ ] Not run (explain below)

# Screenshots / Evidence (if applicable)
- 

# Rollout / Risk
- Impacted areas: collection edit form defaults + `Collection` type only. No API or data-flow changes.
- Rollback plan: revert the commit; toggles return to always-Disabled display.

# Notes
- Backend already persists these fields correctly when sent (`sometimes|boolean` on the `update` ruleset, fillable + boolean cast). The defect was purely the FE not modelling/populating them.
