### PR TITLE
feat(DP-1021): Redesign of the query results

### DIFF
--- a/src/modules/QueryResultsTable/QueryResultsTable.tsx
+++ b/src/modules/QueryResultsTable/QueryResultsTable.tsx
@@ -115,7 +115,7 @@ const QueryResultsTable = ({
         const result = cell.getValue<Result>();
         const { count, status } = result || {};
         if (status === "error" || original.failed_at) {
-          return <ErrorIcon message={original.latest_run?.error_message} />;
+          return 0;
         }
 
         return count === undefined || count === null ? (
@@ -156,6 +156,18 @@ const QueryResultsTable = ({
         const rawStatus = result?.status ?? "pending";
         const displayStatus = DEFAULT_STATUS_LABELS[rawStatus] ?? rawStatus;
         return displayStatus;
+      },
+      size: 100,
+      minSize: 100,
+      maxSize: 100,
+    },
+    {
+      accessorKey: "reason",
+      accessorFn: (row) => row.latest_run?.error_message,
+      header: "Reason",
+      Cell: ({ cell }) => {
+        const value = cell.getValue<string | null>();
+        return value ?? "N/A";
       },
       size: 100,
       minSize: 100,

--- a/src/modules/QueryResultsTable/QueryResultsTable.tsx
+++ b/src/modules/QueryResultsTable/QueryResultsTable.tsx
@@ -3,7 +3,6 @@
 import { Query, Task, Result } from "../../types/api";
 import { MRT_TableOptions, type MRT_ColumnDef } from "material-react-table";
 import { CircularProgress, Link } from "@mui/material";
-import ErrorIcon from "@/components/ErrorIcon";
 import LaunchIcon from "@mui/icons-material/Launch";
 import { useEffect, useMemo } from "react";
 import { useTable } from "../../hooks/useTable";


### PR DESCRIPTION
## Summary

* new column for Reason for failures 

<img width="1501" height="451" alt="image" src="https://github.com/user-attachments/assets/92e2bd7e-4d43-4f7a-aa99-efffe6b90cd0" />


## Jira

https://hdruk.atlassian.net/browse/DP-1021

## PR Type

- [X] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [ ] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [ ] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

<!-- For UI work, add before/after screenshots or short video. -->

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
