### PR TITLE
feat(DP-1024): Make sort button configurable and add it to term directory

### DIFF
--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -14,6 +14,7 @@ const getTermDirectory = async (
   search?: string,
   domain?: DomainTab,
   collections?: string[],
+  sort?: string,
 ): Promise<ApiResponse<Paginated<TermDirectoryEntry>>> => {
   const {
     user: { id: userId },
@@ -40,6 +41,12 @@ const getTermDirectory = async (
   }
 
   collections?.forEach((pid) => params.append("collection_pid[]", pid));
+
+  if (sort) {
+    params.set("sort", sort);
+  }
+
+  console.log("getTermDirectory params:", params.toString());
 
   const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({
     url: API_ROUTES.termDirectory,

--- a/src/actions/termDirectory/getTermDirectory.ts
+++ b/src/actions/termDirectory/getTermDirectory.ts
@@ -46,8 +46,6 @@ const getTermDirectory = async (
     params.set("sort", sort);
   }
 
-  console.log("getTermDirectory params:", params.toString());
-
   const result = await apiGet<ApiResponse<Paginated<TermDirectoryEntry>>>({
     url: API_ROUTES.termDirectory,
     params,

--- a/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostsTable.tsx
+++ b/src/app/(protected)/(custodianAdmin)/custodian-admin/[custodianPid]/[tabId]/components/CollectionHostsTable.tsx
@@ -73,7 +73,13 @@ const CollectionHostsTable = ({
           titleProps: {
             title: "Collection Hosts",
             subTitle: "All",
-            children: <SortButton field="name" />,
+            children: (
+              <SortButton
+                fields={[
+                  { field: "name", displayName: "Name", numeric: false },
+                ]}
+              />
+            ),
             wrapperSx: {
               sx: {
                 display: "flex",

--- a/src/app/(protected)/term-directory/page.tsx
+++ b/src/app/(protected)/term-directory/page.tsx
@@ -20,6 +20,7 @@ const TermDirectoryPageContent = async ({ searchParams }: PageProps) => {
     params?.search_term,
     params?.domain,
     params?.collections?.split(","),
+    params?.sort,
   );
 
   return (

--- a/src/components/PositionedMenu/PositionedMenu.tsx
+++ b/src/components/PositionedMenu/PositionedMenu.tsx
@@ -79,6 +79,7 @@ const PositionedMenu = ({
     ? {
         sx: {
           bgcolor: "white",
+          border: 1,
           borderColor: active ? "success.main" : "transparent",
           borderRadius: "50%",
           height: 36,

--- a/src/components/SortButton/SortButton.tsx
+++ b/src/components/SortButton/SortButton.tsx
@@ -98,6 +98,18 @@ const SortButton = ({ fields, searchParamName = "sort" }: SortButtonProps) => {
     handleSort,
   ]);
 
+  useLogDependencyChanges(
+    "SortButton",
+    {
+      fields,
+      currentField,
+      currentSortDirection,
+      handleSort,
+      clearSearchParams,
+    },
+    { enabled: true },
+  );
+
   return (
     <PositionedMenu isIcon items={items} active={!!currentField}>
       <SortIcon sx={{ width: 20, height: 20 }} />

--- a/src/components/SortButton/SortButton.tsx
+++ b/src/components/SortButton/SortButton.tsx
@@ -10,6 +10,7 @@ import { Typography } from "@mui/material";
 import { SortAscendingIcon } from "@/icons/SortAscendingIcon";
 import { SortDescendingIcon } from "@/icons/SortDescendingIcon";
 import { useCallback, useMemo } from "react";
+import { useLogDependencyChanges } from "@/utils/deps";
 
 export interface SortButtonProps {
   fields: { field: string; displayName: string; numeric: boolean }[];
@@ -46,14 +47,7 @@ const SortButton = ({ fields, searchParamName = "sort" }: SortButtonProps) => {
         ),
         onClick: () => clearSearchParams(),
       },
-    ];
-
-    for (const fieldObj of fields) {
-      const field = fieldObj.field;
-      const displayName = fieldObj.displayName;
-      const numeric = fieldObj.numeric;
-
-      itemsArr.push(
+      ...fields.flatMap(({ field, displayName, numeric }) => [
         {
           id: `${field}:${SortDirection.ASCENDING}`,
           label: (
@@ -92,8 +86,8 @@ const SortButton = ({ fields, searchParamName = "sort" }: SortButtonProps) => {
           ),
           onClick: () => handleSort(field, SortDirection.DESCENDING),
         },
-      );
-    }
+      ]),
+    ];
 
     return itemsArr;
   }, [

--- a/src/components/SortButton/SortButton.tsx
+++ b/src/components/SortButton/SortButton.tsx
@@ -10,7 +10,6 @@ import { Typography } from "@mui/material";
 import { SortAscendingIcon } from "@/icons/SortAscendingIcon";
 import { SortDescendingIcon } from "@/icons/SortDescendingIcon";
 import { useCallback, useMemo } from "react";
-import { useLogDependencyChanges } from "@/utils/deps";
 
 export interface SortButtonProps {
   fields: { field: string; displayName: string; numeric: boolean }[];

--- a/src/components/SortButton/SortButton.tsx
+++ b/src/components/SortButton/SortButton.tsx
@@ -9,7 +9,7 @@ import { SortDirection } from "@/types/common";
 import { Typography } from "@mui/material";
 import { SortAscendingIcon } from "@/icons/SortAscendingIcon";
 import { SortDescendingIcon } from "@/icons/SortDescendingIcon";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 export interface SortButtonProps {
   fields: { field: string; displayName: string; numeric: boolean }[];
@@ -31,108 +31,81 @@ const SortButton = ({ fields, searchParamName = "sort" }: SortButtonProps) => {
     [currentSortDirection, currentField, setSearchParam],
   );
 
-  const itemsArr: PositionedMenuItem[] = [
-    {
-      id: "none",
-      label: (
-        <Typography
-          component="span"
-          sx={{ display: "flex", alignItems: "center" }}
-          fontWeight={!currentField ? "bold" : "normal"}
-        >
-          <SortAscendingIcon sx={{ mr: 1 }} /> Clear sorting
-        </Typography>
-      ),
-      onClick: () => clearSearchParams(),
-    },
-  ];
-
-  for (const fieldObj of fields) {
-    const field = fieldObj.field;
-    const displayName = fieldObj.displayName;
-    const numeric = fieldObj.numeric;
-
-    console.log("field:", field, "displayName:", displayName);
-
-    itemsArr.push(
+  const items = useMemo(() => {
+    const itemsArr: PositionedMenuItem[] = [
       {
-        id: `${field}:${SortDirection.ASCENDING}`,
+        id: "none",
         label: (
           <Typography
             component="span"
             sx={{ display: "flex", alignItems: "center" }}
-            fontWeight={
-              currentField === field &&
-              currentSortDirection === SortDirection.ASCENDING
-                ? "bold"
-                : "normal"
-            }
+            fontWeight={!currentField ? "bold" : "normal"}
           >
-            <SortAscendingIcon sx={{ mr: 1 }} /> Sort by {displayName}{" "}
-            {numeric ? "(Low-High)" : "(A-Z)"}
+            <SortAscendingIcon sx={{ mr: 1 }} /> Clear sorting
           </Typography>
         ),
-        onClick: () => handleSort(field, SortDirection.ASCENDING),
+        onClick: () => clearSearchParams(),
       },
-      {
-        id: `${field}:${SortDirection.DESCENDING}`,
-        label: (
-          <Typography
-            component="span"
-            sx={{ display: "flex", alignItems: "center" }}
-            fontWeight={
-              currentField === field &&
-              currentSortDirection === SortDirection.DESCENDING
-                ? "bold"
-                : "normal"
-            }
-          >
-            <SortDescendingIcon sx={{ mr: 1 }} /> Sort by {displayName}{" "}
-            {numeric ? "(High-Low)" : "(Z-A)"}
-          </Typography>
-        ),
-        onClick: () => handleSort(field, SortDirection.DESCENDING),
-      },
-    );
-  }
+    ];
 
-  console.log("itemsArr:", itemsArr);
+    for (const fieldObj of fields) {
+      const field = fieldObj.field;
+      const displayName = fieldObj.displayName;
+      const numeric = fieldObj.numeric;
 
-  // const items: PositionedMenuItem[] = [
-  //   {
-  //     id: SortDirection.ASCENDING,
-  //     label: (
-  //       <Typography
-  //         component="span"
-  //         sx={{ display: "flex", alignItems: "center" }}
-  //         fontWeight={
-  //           currentSortDirection == SortDirection.ASCENDING ? "bold" : "normal"
-  //         }
-  //       >
-  //         <SortAscendingIcon sx={{ mr: 1 }} /> Sort alphabetically (A-Z)
-  //       </Typography>
-  //     ),
-  //     onClick: () => handleSort(SortDirection.ASCENDING),
-  //   },
-  //   {
-  //     id: SortDirection.DESCENDING,
-  //     label: (
-  //       <Typography
-  //         component="span"
-  //         sx={{ display: "flex", alignItems: "center" }}
-  //         fontWeight={
-  //           currentSortDirection == SortDirection.DESCENDING ? "bold" : "normal"
-  //         }
-  //       >
-  //         <SortDescendingIcon sx={{ mr: 1 }} /> Sort alphabetically (Z-A)
-  //       </Typography>
-  //     ),
-  //     onClick: () => handleSort(SortDirection.DESCENDING),
-  //   },
-  // ];
+      itemsArr.push(
+        {
+          id: `${field}:${SortDirection.ASCENDING}`,
+          label: (
+            <Typography
+              component="span"
+              sx={{ display: "flex", alignItems: "center" }}
+              fontWeight={
+                currentField === field &&
+                currentSortDirection === SortDirection.ASCENDING
+                  ? "bold"
+                  : "normal"
+              }
+            >
+              <SortAscendingIcon sx={{ mr: 1 }} /> Sort by {displayName}{" "}
+              {numeric ? "(Low-High)" : "(A-Z)"}
+            </Typography>
+          ),
+          onClick: () => handleSort(field, SortDirection.ASCENDING),
+        },
+        {
+          id: `${field}:${SortDirection.DESCENDING}`,
+          label: (
+            <Typography
+              component="span"
+              sx={{ display: "flex", alignItems: "center" }}
+              fontWeight={
+                currentField === field &&
+                currentSortDirection === SortDirection.DESCENDING
+                  ? "bold"
+                  : "normal"
+              }
+            >
+              <SortDescendingIcon sx={{ mr: 1 }} /> Sort by {displayName}{" "}
+              {numeric ? "(High-Low)" : "(Z-A)"}
+            </Typography>
+          ),
+          onClick: () => handleSort(field, SortDirection.DESCENDING),
+        },
+      );
+    }
+
+    return itemsArr;
+  }, [
+    currentField,
+    clearSearchParams,
+    fields,
+    currentSortDirection,
+    handleSort,
+  ]);
 
   return (
-    <PositionedMenu isIcon items={itemsArr} active={!!currentField}>
+    <PositionedMenu isIcon items={items} active={!!currentField}>
       <SortIcon sx={{ width: 20, height: 20 }} />
     </PositionedMenu>
   );

--- a/src/components/SortButton/SortButton.tsx
+++ b/src/components/SortButton/SortButton.tsx
@@ -98,18 +98,6 @@ const SortButton = ({ fields, searchParamName = "sort" }: SortButtonProps) => {
     handleSort,
   ]);
 
-  useLogDependencyChanges(
-    "SortButton",
-    {
-      fields,
-      currentField,
-      currentSortDirection,
-      handleSort,
-      clearSearchParams,
-    },
-    { enabled: true },
-  );
-
   return (
     <PositionedMenu isIcon items={items} active={!!currentField}>
       <SortIcon sx={{ width: 20, height: 20 }} />

--- a/src/components/SortButton/SortButton.tsx
+++ b/src/components/SortButton/SortButton.tsx
@@ -99,7 +99,12 @@ const SortButton = ({ fields, searchParamName = "sort" }: SortButtonProps) => {
   ]);
 
   return (
-    <PositionedMenu isIcon items={items} active={!!currentField}>
+    <PositionedMenu
+      isIcon
+      items={items}
+      active={!!currentField}
+      aria-label="Sort"
+    >
       <SortIcon sx={{ width: 20, height: 20 }} />
     </PositionedMenu>
   );

--- a/src/components/SortButton/SortButton.tsx
+++ b/src/components/SortButton/SortButton.tsx
@@ -12,58 +12,127 @@ import { SortDescendingIcon } from "@/icons/SortDescendingIcon";
 import { useCallback } from "react";
 
 export interface SortButtonProps {
-  field: string;
+  fields: { field: string; displayName: string; numeric: boolean }[];
   searchParamName?: string;
 }
 
-const SortButton = ({ field, searchParamName = "sort" }: SortButtonProps) => {
-  const { getSearchParam, setSearchParam } = useSearchParams(searchParamName);
+const SortButton = ({ fields, searchParamName = "sort" }: SortButtonProps) => {
+  const { getSearchParam, setSearchParam, clearSearchParams } =
+    useSearchParams(searchParamName);
+  const currentField = getSearchParam()?.split(":")[0];
   const currentSortDirection = getSearchParam()?.split(":")[1];
 
   const handleSort = useCallback(
-    (direction: SortDirection) => {
-      setSearchParam(
-        direction !== currentSortDirection ? `${field}:${direction}` : null,
-      );
+    (field: string, direction: SortDirection) => {
+      if (field !== currentField || direction !== currentSortDirection) {
+        setSearchParam(`${field}:${direction}`);
+      }
     },
-    [field, currentSortDirection, setSearchParam],
+    [currentSortDirection, currentField, setSearchParam],
   );
 
-  const items: PositionedMenuItem[] = [
+  const itemsArr: PositionedMenuItem[] = [
     {
-      id: SortDirection.ASCENDING,
+      id: "none",
       label: (
         <Typography
           component="span"
           sx={{ display: "flex", alignItems: "center" }}
-          fontWeight={
-            currentSortDirection == SortDirection.ASCENDING ? "bold" : "normal"
-          }
+          fontWeight={!currentField ? "bold" : "normal"}
         >
-          <SortAscendingIcon sx={{ mr: 1 }} /> Sort alphabetically (A-Z)
+          <SortAscendingIcon sx={{ mr: 1 }} /> Clear sorting
         </Typography>
       ),
-      onClick: () => handleSort(SortDirection.ASCENDING),
-    },
-    {
-      id: SortDirection.DESCENDING,
-      label: (
-        <Typography
-          component="span"
-          sx={{ display: "flex", alignItems: "center" }}
-          fontWeight={
-            currentSortDirection == SortDirection.DESCENDING ? "bold" : "normal"
-          }
-        >
-          <SortDescendingIcon sx={{ mr: 1 }} /> Sort alphabetically (Z-A)
-        </Typography>
-      ),
-      onClick: () => handleSort(SortDirection.DESCENDING),
+      onClick: () => clearSearchParams(),
     },
   ];
 
+  for (const fieldObj of fields) {
+    const field = fieldObj.field;
+    const displayName = fieldObj.displayName;
+    const numeric = fieldObj.numeric;
+
+    console.log("field:", field, "displayName:", displayName);
+
+    itemsArr.push(
+      {
+        id: `${field}:${SortDirection.ASCENDING}`,
+        label: (
+          <Typography
+            component="span"
+            sx={{ display: "flex", alignItems: "center" }}
+            fontWeight={
+              currentField === field &&
+              currentSortDirection === SortDirection.ASCENDING
+                ? "bold"
+                : "normal"
+            }
+          >
+            <SortAscendingIcon sx={{ mr: 1 }} /> Sort by {displayName}{" "}
+            {numeric ? "(Low-High)" : "(A-Z)"}
+          </Typography>
+        ),
+        onClick: () => handleSort(field, SortDirection.ASCENDING),
+      },
+      {
+        id: `${field}:${SortDirection.DESCENDING}`,
+        label: (
+          <Typography
+            component="span"
+            sx={{ display: "flex", alignItems: "center" }}
+            fontWeight={
+              currentField === field &&
+              currentSortDirection === SortDirection.DESCENDING
+                ? "bold"
+                : "normal"
+            }
+          >
+            <SortDescendingIcon sx={{ mr: 1 }} /> Sort by {displayName}{" "}
+            {numeric ? "(High-Low)" : "(Z-A)"}
+          </Typography>
+        ),
+        onClick: () => handleSort(field, SortDirection.DESCENDING),
+      },
+    );
+  }
+
+  console.log("itemsArr:", itemsArr);
+
+  // const items: PositionedMenuItem[] = [
+  //   {
+  //     id: SortDirection.ASCENDING,
+  //     label: (
+  //       <Typography
+  //         component="span"
+  //         sx={{ display: "flex", alignItems: "center" }}
+  //         fontWeight={
+  //           currentSortDirection == SortDirection.ASCENDING ? "bold" : "normal"
+  //         }
+  //       >
+  //         <SortAscendingIcon sx={{ mr: 1 }} /> Sort alphabetically (A-Z)
+  //       </Typography>
+  //     ),
+  //     onClick: () => handleSort(SortDirection.ASCENDING),
+  //   },
+  //   {
+  //     id: SortDirection.DESCENDING,
+  //     label: (
+  //       <Typography
+  //         component="span"
+  //         sx={{ display: "flex", alignItems: "center" }}
+  //         fontWeight={
+  //           currentSortDirection == SortDirection.DESCENDING ? "bold" : "normal"
+  //         }
+  //       >
+  //         <SortDescendingIcon sx={{ mr: 1 }} /> Sort alphabetically (Z-A)
+  //       </Typography>
+  //     ),
+  //     onClick: () => handleSort(SortDirection.DESCENDING),
+  //   },
+  // ];
+
   return (
-    <PositionedMenu isIcon items={items} active={!!currentSortDirection}>
+    <PositionedMenu isIcon items={itemsArr} active={!!currentField}>
       <SortIcon sx={{ width: 20, height: 20 }} />
     </PositionedMenu>
   );

--- a/src/modules/QueriesTable/QueriesTable.tsx
+++ b/src/modules/QueriesTable/QueriesTable.tsx
@@ -324,7 +324,9 @@ const QueriesTable = ({
             },
           }}
           rightAction={{
-            sortProps: { field: "name" },
+            sortProps: {
+              fields: [{ field: "name", displayName: "Name", numeric: false }],
+            },
           }}
         />
       }

--- a/src/modules/TermDirectory/TermDirectory.test.tsx
+++ b/src/modules/TermDirectory/TermDirectory.test.tsx
@@ -8,12 +8,13 @@ import { mockTermDirectoryEntries } from "@/actions/termDirectory/__mocks__/getT
 import { paginateData } from "@/utils/mock";
 import { TermDirectoryEntry, Paginated } from "@/types/api";
 
+const mockReplace = jest.fn();
 let mockSearchParams = new URLSearchParams("page=1&per_page=5");
 
 jest.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
   usePathname: () => "/term-directory",
-  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useRouter: () => ({ push: jest.fn(), replace: mockReplace }),
 }));
 
 const renderComponent = (entries: Paginated<TermDirectoryEntry>) =>
@@ -26,6 +27,11 @@ const renderComponent = (entries: Paginated<TermDirectoryEntry>) =>
   );
 
 describe("TermDirectory", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockSearchParams = new URLSearchParams();
+  });
+
   it("renders the correct column headers", () => {
     renderComponent(paginateData({ data: mockTermDirectoryEntries }));
 
@@ -139,5 +145,87 @@ describe("TermDirectory", () => {
     );
 
     expect(screen.getByText("1-5 of 100")).toBeInTheDocument();
+  });
+
+  it("renders a sort button with the correct fields", async () => {
+    const user = userEvent.setup();
+
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
+
+    expect(screen.getByLabelText("Sort")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Sort"));
+
+    // The sort options menu and its items
+    expect(await screen.getByRole("tooltip")).toBeInTheDocument();
+
+    expect(
+      await screen.getByRole("menuitem", { name: "Clear sorting" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.getByRole("menuitem", { name: "Sort by Term Name (A-Z)" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.getByRole("menuitem", { name: "Sort by Term Name (Z-A)" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.getByRole("menuitem", { name: "Sort by Count (Low-High)" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.getByRole("menuitem", { name: "Sort by Count (High-Low)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("updates the URL search params when sort options are clicked", async () => {
+    const user = userEvent.setup();
+
+    mockSearchParams = new URLSearchParams("page=1&per_page=5");
+
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
+
+    await user.click(screen.getByLabelText("Sort"));
+    await user.click(
+      screen.getByRole("menuitem", { name: "Sort by Term Name (A-Z)" }),
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      "?page=1&per_page=5&sort=concept_name%3Aasc",
+    );
+
+    mockReplace.mockClear();
+
+    await user.click(screen.getByLabelText("Sort"));
+    await user.click(
+      screen.getByRole("menuitem", { name: "Sort by Count (High-Low)" }),
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      "?page=1&per_page=5&sort=count%3Adesc",
+    );
+  });
+
+  it("removes the sort parameter when clear sorting is clicked", async () => {
+    const user = userEvent.setup();
+
+    mockSearchParams = new URLSearchParams("page=1&per_page=5");
+
+    renderComponent(paginateData({ data: mockTermDirectoryEntries }));
+
+    await user.click(screen.getByLabelText("Sort"));
+    await user.click(
+      screen.getByRole("menuitem", { name: "Sort by Term Name (A-Z)" }),
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      "?page=1&per_page=5&sort=concept_name%3Aasc",
+    );
+
+    mockReplace.mockClear();
+    mockSearchParams = new URLSearchParams();
+
+    await user.click(screen.getByLabelText("Sort"));
+    await user.click(screen.getByRole("menuitem", { name: "Clear sorting" }));
+
+    expect(mockReplace).toHaveBeenCalledWith("/term-directory");
   });
 });

--- a/src/modules/TermDirectory/TermDirectory.tsx
+++ b/src/modules/TermDirectory/TermDirectory.tsx
@@ -93,6 +93,14 @@ const TermDirectory = ({
           placeholder: "Search by term name or OMOP ID...",
         },
       }}
+      rightAction={{
+        sortProps: {
+          fields: [
+            { field: "concept_name", displayName: "Term Name", numeric: false },
+            { field: "count", displayName: "Count", numeric: true },
+          ],
+        },
+      }}
       details={<DomainFilterTabs />}
       boxSxProps={{
         "& > .MuiGrid-container": {
@@ -101,6 +109,9 @@ const TermDirectory = ({
         },
         "& .MuiPaper-root": {
           borderRadius: 0,
+        },
+        "& .MuiGrid-root": {
+          alignItems: "center",
         },
       }}
     />


### PR DESCRIPTION
## Summary

This PR implements the following:

- Made the sort button configurable rather than only allowing 1 chosen sortable field with hardcoded text
- Added a “Clear sorting” button that utilizes “clearSearchParams” from the useSearchParams hook (currently using the same icon as the other sorting fields)
- Adjusted Query History table to fit new fields
- Extended the term directory server action to support sorting
- Added the sort button to the right of the TD search bar using “rightProps” in the same way that Query History does, and centered it vertically

## Jira

https://hdruk.atlassian.net/browse/DP-1024

## PR Type

- [X] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

This repo validates PR titles in CI. Use one of:

- `feat(DP-1234): short description`
- `fix!(DP-5678): short description` (breaking change)
- `RELEASE: vX.Y.Z`

## Changes Included

- [X] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [X] Test updates
- [ ] Documentation updates

## Validation

Run locally before requesting review:

- [X] `npm run lint` passes
- [X] `npm run test` passes
- [X] `npm run build` passes
- [ ] `npm run build-storybook` passes (if UI changes)

## Coding Conventions Checklist

- [ ] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [ ] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [ ] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs)
- [ ] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components)
- [ ] Side-effectful endpoints are not cached unintentionally
- [ ] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

https://github.com/user-attachments/assets/b4afc87d-244b-40f9-bd76-11df2de93f24

## Risk and Rollback

- Risk level: <!-- low / medium / high -->
- Main risk areas:
  - <!-- e.g. query submission flow, auth redirect, table pagination -->
- Rollback plan:
  - <!-- e.g. revert PR, feature-flag off, deploy previous release tag -->

## Notes for Reviewers

<!-- Anything specific you want reviewers to focus on. -->
