### PR TITLE
refactor(DP-1091): draft-until-save editing for the demographics panel

### DIFF
--- a/src/modules/DemographicsPanel/DemographicAgeSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicAgeSection.tsx
@@ -1,45 +1,49 @@
 "use client";
 
+import { Controller, useFormContext } from "react-hook-form";
 import { Box, Chip } from "@mui/material";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
+import { Demographics } from "@/types/rules";
 import AgeRangeInput from "@/components/RuleAgeSelector/AgeRangeInput";
-import DemographicRow from "./DemographicRow";
+import DemographicRow, { DemographicRowActionProps } from "./DemographicRow";
 import { formatAgeSummary } from "./summary";
 
 const DEFAULT_AGE_RANGE: [number, number] = [MIN_AGE_FILTER, MAX_AGE_FILTER];
 
-const DemographicAgeSection = () => {
-  const { age, setAge } = useQueryBuilder((qb) => ({
+const DemographicAgeSection = (props: DemographicRowActionProps) => {
+  const { control, setValue } = useFormContext<Demographics>();
+
+  const { age } = useQueryBuilder((qb) => ({
     age: qb.queryBuilderJson.demographics?.age ?? null,
-    setAge: qb.setDemographicsAge,
   }));
 
-  const handleEdit = () => {
-    if (!age) setAge(DEFAULT_AGE_RANGE);
-  };
-
-  const handleClear = () => {
-    setAge(null);
+  const handleEditStart = () => {
+    props.onEditStart();
+    if (!age) setValue("age", DEFAULT_AGE_RANGE);
   };
 
   return (
     <DemographicRow
       label="Age"
-      onEdit={handleEdit}
-      onClear={handleClear}
+      {...props}
+      onEditStart={handleEditStart}
       showClear={age !== null}
       renderEditing={
         <Box minWidth={350} maxWidth={400}>
-          {age && (
-            <AgeRangeInput
-              value={age}
-              minAge={MIN_AGE_FILTER}
-              maxAge={MAX_AGE_FILTER}
-              onChange={setAge}
-              sx={{ flex: 1, py: 1 }}
-            />
-          )}
+          <Controller
+            name="age"
+            control={control}
+            render={({ field }) => (
+              <AgeRangeInput
+                value={field.value ?? DEFAULT_AGE_RANGE}
+                minAge={MIN_AGE_FILTER}
+                maxAge={MAX_AGE_FILTER}
+                onChange={field.onChange}
+                sx={{ flex: 1, py: 1 }}
+              />
+            )}
+          />
         </Box>
       }
     >

--- a/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Controller, useFormContext } from "react-hook-form";
 import {
   Button,
   Chip,
@@ -10,11 +11,12 @@ import {
 } from "@mui/material";
 import SquareCheckbox from "@/components/SquareCheckbox";
 import { Concept, TermDirectoryEntry } from "@/types/api";
+import { Demographics } from "@/types/rules";
 import {
   demographicGuidance,
   demographicOptionToConcept,
 } from "@/config/demographics";
-import DemographicRow from "./DemographicRow";
+import DemographicRow, { DemographicRowActionProps } from "./DemographicRow";
 import { capitaliseFirstLetter } from "@/utils/string";
 
 // Above this many options the checkboxes flow into a scrollable multi-column
@@ -25,26 +27,21 @@ const MULTI_COLUMN_THRESHOLD = 10;
 // the rest into a "+N more" chip.
 const MAX_VISIBLE_CHIPS = 6;
 
-interface DemographicCheckboxSectionProps {
+interface DemographicCheckboxSectionProps extends DemographicRowActionProps {
   label: string;
+  field: "sex" | "race";
   options: TermDirectoryEntry[];
   selected: Concept[];
-  onToggle: (concept: Concept, selected: boolean) => void;
-  onSetAll: (concepts: Concept[]) => void;
-  onClear: () => void;
 }
 
 const DemographicCheckboxSection = ({
   label,
+  field,
   options,
   selected,
-  onToggle,
-  onSetAll,
-  onClear,
+  ...actionProps
 }: DemographicCheckboxSectionProps) => {
-  const isChecked = (conceptId: number) =>
-    selected.some((c) => c.concept_id === conceptId);
-
+  const { control } = useFormContext<Demographics>();
   const note = demographicGuidance(label.toLowerCase());
 
   const sortedOptions = [...options].sort((a, b) =>
@@ -54,18 +51,11 @@ const DemographicCheckboxSection = ({
   );
 
   const isMultiColumn = options.length > MULTI_COLUMN_THRESHOLD;
-  const allSelected =
-    options.length > 0 && options.every((o) => isChecked(o.concept_id));
-
-  const handleToggleAll = () =>
-    allSelected
-      ? onClear()
-      : onSetAll(sortedOptions.map(demographicOptionToConcept));
 
   return (
     <DemographicRow
       label={label}
-      onClear={onClear}
+      {...actionProps}
       showClear={selected.length > 0}
       renderEditing={
         options.length === 0 ? (
@@ -73,69 +63,105 @@ const DemographicCheckboxSection = ({
             {`No ${label.toLowerCase()} options are available — the collections you have selected do not contain this data.`}
           </Typography>
         ) : (
-          <>
-            {isMultiColumn && (
-              <Button
-                variant="text"
-                size="small"
-                color="secondary"
-                onClick={handleToggleAll}
-                sx={{ alignSelf: "flex-start", mb: 0.5 }}
-              >
-                {allSelected ? "Deselect all" : "Select all"}
-              </Button>
-            )}
-            <FormGroup
-              sx={
-                isMultiColumn
-                  ? {
-                      display: "grid",
-                      gridTemplateColumns:
-                        "repeat(auto-fill, minmax(220px, 1fr))",
-                      width: "100%",
-                      maxHeight: 400,
-                      overflowY: "auto",
-                      pr: 1,
-                    }
-                  : undefined
-              }
-            >
-              {sortedOptions.map((option) => (
-                <FormControlLabel
-                  key={option.concept_id}
-                  sx={{
-                    minWidth: 0,
-                    alignItems: "flex-start",
-                    "& .MuiFormControlLabel-label": {
-                      mt: "9px",
-                      whiteSpace: "normal",
-                      overflowWrap: "anywhere",
-                    },
-                  }}
-                  control={
-                    <SquareCheckbox
-                      checked={isChecked(option.concept_id)}
-                      onChange={(_e, checked) =>
-                        onToggle(demographicOptionToConcept(option), checked)
-                      }
-                    />
-                  }
-                  label={capitaliseFirstLetter(
-                    option.concept_name.toLocaleLowerCase(),
+          <Controller
+            name={field}
+            control={control}
+            render={({ field: draftField }) => {
+              const draft = draftField.value;
+              const isChecked = (conceptId: number) =>
+                draft.some((c) => c.concept_id === conceptId);
+              const allSelected =
+                options.length > 0 && options.every((o) => isChecked(o.concept_id));
+
+              const handleToggleAll = () =>
+                draftField.onChange(
+                  allSelected
+                    ? []
+                    : sortedOptions.map(demographicOptionToConcept),
+                );
+
+              const handleToggle = (concept: Concept, checked: boolean) =>
+                draftField.onChange(
+                  checked
+                    ? [
+                        ...draft.filter(
+                          (c) => c.concept_id !== concept.concept_id,
+                        ),
+                        concept,
+                      ]
+                    : draft.filter((c) => c.concept_id !== concept.concept_id),
+                );
+
+              return (
+                <>
+                  {isMultiColumn && (
+                    <Button
+                      variant="text"
+                      size="small"
+                      color="secondary"
+                      onClick={handleToggleAll}
+                      sx={{ alignSelf: "flex-start", mb: 0.5 }}
+                    >
+                      {allSelected ? "Deselect all" : "Select all"}
+                    </Button>
                   )}
-                />
-              ))}
-            </FormGroup>
-            {note && (
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{ mt: 0.5 }}
-              >
-                {note}
-              </Typography>
-            )}
-          </>
+                  <FormGroup
+                    sx={
+                      isMultiColumn
+                        ? {
+                            display: "grid",
+                            gridTemplateColumns:
+                              "repeat(auto-fill, minmax(220px, 1fr))",
+                            width: "100%",
+                            maxHeight: 400,
+                            overflowY: "auto",
+                            pr: 1,
+                          }
+                        : undefined
+                    }
+                  >
+                    {sortedOptions.map((option) => (
+                      <FormControlLabel
+                        key={option.concept_id}
+                        sx={{
+                          minWidth: 0,
+                          alignItems: "flex-start",
+                          "& .MuiFormControlLabel-label": {
+                            mt: "9px",
+                            whiteSpace: "normal",
+                            overflowWrap: "anywhere",
+                          },
+                        }}
+                        control={
+                          <SquareCheckbox
+                            checked={isChecked(option.concept_id)}
+                            onChange={(_e, checked) =>
+                              handleToggle(
+                                demographicOptionToConcept(option),
+                                checked,
+                              )
+                            }
+                          />
+                        }
+                        label={capitaliseFirstLetter(
+                          option.concept_name.toLocaleLowerCase(),
+                        )}
+                      />
+                    ))}
+                  </FormGroup>
+                  {note && (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mt: 0.5 }}
+                    >
+                      {note}
+                    </Typography>
+                  )}
+                </>
+              );
+            }}
+          />
         )
       }
     >

--- a/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicCheckboxSection.tsx
@@ -172,7 +172,7 @@ const DemographicCheckboxSection = ({
               key={c.concept_id}
               variant="outlined"
               sx={{ bgcolor: "white" }}
-              label={c.name}
+              label={capitaliseFirstLetter(c.name.toLocaleLowerCase())}
             />
           ))}
           {selected.length > MAX_VISIBLE_CHIPS && (

--- a/src/modules/DemographicsPanel/DemographicConceptSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicConceptSection.tsx
@@ -25,11 +25,43 @@ const DemographicConceptSection = ({
   onToggle,
   onClear,
 }: DemographicConceptSectionProps) => {
-  const [selected, setSelected] = useState<Record<number, boolean>>({});
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<Record<number, boolean>>({});
+  const [draftConcepts, setDraftConcepts] = useState<Record<number, Concept>>(
+    {},
+  );
 
-  const handleRemove = (concept: Concept) => {
-    setSelected((prev) => ({ ...prev, [concept.concept_id]: false }));
-    onToggle(concept, false);
+  const handleEditStart = () => {
+    setDraft(toSelectedMap(concepts));
+    setDraftConcepts(
+      Object.fromEntries(concepts.map((c) => [c.concept_id, c])),
+    );
+    setEditing(true);
+  };
+
+  const handleDraftToggle = (concept: Concept, selected: boolean) => {
+    setDraft((prev) => ({ ...prev, [concept.concept_id]: selected }));
+    setDraftConcepts((prev) => ({ ...prev, [concept.concept_id]: concept }));
+  };
+
+  const handleSave = () => {
+    const committedIds = new Set(concepts.map((c) => c.concept_id));
+    const draftIds = new Set(
+      Object.entries(draft)
+        .filter(([, selected]) => selected)
+        .map(([id]) => Number(id)),
+    );
+
+    concepts.forEach((concept) => {
+      if (!draftIds.has(concept.concept_id)) onToggle(concept, false);
+    });
+    draftIds.forEach((id) => {
+      if (!committedIds.has(id) && draftConcepts[id]) {
+        onToggle(draftConcepts[id], true);
+      }
+    });
+
+    setEditing(false);
   };
 
   const selectedChips = concepts.length > 0 && (
@@ -40,7 +72,7 @@ const DemographicConceptSection = ({
           concept={c}
           onDelete={(e) => {
             e.stopPropagation();
-            handleRemove(c);
+            onToggle(c, false);
           }}
         />
       ))}
@@ -50,7 +82,12 @@ const DemographicConceptSection = ({
   return (
     <DemographicRow
       label={label}
-      onEdit={() => setSelected(toSelectedMap(concepts))}
+      editing={editing}
+      disabled={false}
+      hideActions={false}
+      onEditStart={handleEditStart}
+      onSave={handleSave}
+      onReset={() => setEditing(false)}
       onClear={onClear}
       showClear={concepts.length > 0}
       renderEditing={
@@ -58,11 +95,10 @@ const DemographicConceptSection = ({
           <SearchConcepts
             domain={domain}
             multiple
-            selected={selected}
-            setSelected={setSelected}
-            onToggle={onToggle}
+            selected={draft}
+            setSelected={setDraft}
+            onToggle={handleDraftToggle}
           />
-          {selectedChips}
         </Box>
       }
     >

--- a/src/modules/DemographicsPanel/DemographicLocationSection.test.tsx
+++ b/src/modules/DemographicsPanel/DemographicLocationSection.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm } from "react-hook-form";
 import {
   DEFAULT_QUERY,
+  EMPTY_DEMOGRAPHICS,
   useQueryBuilderStore,
 } from "@/store/queryBuilderStore";
+import { Demographics } from "@/types/rules";
 import DemographicLocationSection from "./DemographicLocationSection";
 
 // The real picker pulls in leaflet (touches `window` at import) — replace it
@@ -21,15 +24,42 @@ jest.mock("next/dynamic", () => ({
 }));
 
 const store = () => useQueryBuilderStore.getState();
-const location = () => store().queryBuilderJson.demographics?.location;
 
 const setLondon = () =>
-  store().setDemographicsLocation({
-    lat: 51.5,
-    lon: -0.1,
-    radius: 50000,
-    address: "London",
+  store().setDemographics({
+    ...(store().queryBuilderJson.demographics ?? EMPTY_DEMOGRAPHICS),
+    location: { lat: 51.5, lon: -0.1, radius: 50000, address: "London" },
   });
+
+const Harness = ({
+  editing = false,
+  onSave = jest.fn(),
+  onReset = jest.fn(),
+  onClear = jest.fn(),
+}: {
+  editing?: boolean;
+  onSave?: () => void;
+  onReset?: () => void;
+  onClear?: () => void;
+}) => {
+  const form = useForm<Demographics>({
+    defaultValues: store().queryBuilderJson.demographics ?? EMPTY_DEMOGRAPHICS,
+  });
+
+  return (
+    <FormProvider {...form}>
+      <DemographicLocationSection
+        editing={editing}
+        disabled={false}
+        hideActions={false}
+        onEditStart={() => {}}
+        onSave={onSave}
+        onReset={onReset}
+        onClear={onClear}
+      />
+    </FormProvider>
+  );
+};
 
 beforeEach(() => {
   store().setQueryBuilderJson(DEFAULT_QUERY);
@@ -38,32 +68,30 @@ beforeEach(() => {
 
 describe("DemographicLocationSection", () => {
   it("renders the Location row with an Any chip by default", () => {
-    render(<DemographicLocationSection />);
+    render(<Harness />);
     expect(screen.getByText(/Location/)).toBeInTheDocument();
     expect(screen.getByText("Any")).toBeInTheDocument();
   });
 
   it("summarises a set location", () => {
     setLondon();
-    render(<DemographicLocationSection />);
+    render(<Harness />);
     expect(
       screen.getByText("Within 50.0 km of London"),
     ).toBeInTheDocument();
   });
 
   it("reveals the map picker and guidance when editing", async () => {
-    render(<DemographicLocationSection />);
-    await userEvent.click(
-      screen.getByRole("button", { name: /edit location/i }),
-    );
+    render(<Harness editing />);
     expect(screen.getByTestId("geo-map-picker")).toBeInTheDocument();
     expect(screen.getByText(/drop a pin/i)).toBeInTheDocument();
   });
 
   it("clears the location via Clear all", async () => {
     setLondon();
-    render(<DemographicLocationSection />);
+    const onClear = jest.fn();
+    render(<Harness onClear={onClear} />);
     await userEvent.click(screen.getByRole("button", { name: /clear all/i }));
-    expect(location()).toBeNull();
+    expect(onClear).toHaveBeenCalled();
   });
 });

--- a/src/modules/DemographicsPanel/DemographicLocationSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicLocationSection.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { Controller, useFormContext } from "react-hook-form";
 import { Box, Chip, Skeleton, Stack, Typography } from "@mui/material";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import { formatRadius } from "@/components/GeoMap";
 import { locationGuidance } from "@/config/demographics";
-import DemographicRow from "./DemographicRow";
+import { Demographics } from "@/types/rules";
+import DemographicRow, { DemographicRowActionProps } from "./DemographicRow";
 
 // Leaflet touches `window` at module load, so the map must never render on the
 // server — load it only in the browser once the row is being edited.
@@ -14,10 +16,10 @@ const GeoMapPicker = dynamic(() => import("@/components/GeoMap/GeoMapPicker"), {
   loading: () => <Skeleton variant="rectangular" height={500} />,
 });
 
-const DemographicLocationSection = () => {
-  const { location, setLocation } = useQueryBuilder((qb) => ({
+const DemographicLocationSection = (props: DemographicRowActionProps) => {
+  const { control } = useFormContext<Demographics>();
+  const { location } = useQueryBuilder((qb) => ({
     location: qb.queryBuilderJson.demographics?.location ?? null,
-    setLocation: qb.setDemographicsLocation,
   }));
 
   const summaryLabel = location
@@ -30,17 +32,23 @@ const DemographicLocationSection = () => {
   return (
     <DemographicRow
       label="Location"
-      onClear={() => setLocation(null)}
+      {...props}
       showClear={location !== null}
       renderEditing={
         <Box
           sx={{ maxHeight: 450, overflowY: "auto", overflowX: "hidden", pr: 1 }}
         >
           <Stack spacing={1} marginX={10}>
-            <GeoMapPicker
-              value={location}
-              onChange={setLocation}
-              mapHeight={400}
+            <Controller
+              name="location"
+              control={control}
+              render={({ field }) => (
+                <GeoMapPicker
+                  value={field.value}
+                  onChange={field.onChange}
+                  mapHeight={400}
+                />
+              )}
             />
             <Typography variant="body2" color="text.secondary">
               {locationGuidance}

--- a/src/modules/DemographicsPanel/DemographicRow.tsx
+++ b/src/modules/DemographicsPanel/DemographicRow.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
 import { Box, Button, Divider, IconButton, Stack } from "@mui/material";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import Title from "@/components/Title";
+import DemographicSaveButton from "./DemographicSaveButton";
 
-interface DemographicRowProps {
+export interface DemographicRowActionProps {
+  editing: boolean;
+  disabled: boolean;
+  hideActions: boolean;
+  onEditStart: () => void;
+  onSave: () => void;
+  onReset: () => void;
+  onClear: () => void;
+}
+
+interface DemographicRowProps extends DemographicRowActionProps {
   label: string;
-  onEdit?: () => void;
-  onSave?: () => void;
-  onClear?: () => void;
   showClear?: boolean;
   children: ReactNode;
   renderEditing: ReactNode;
@@ -17,29 +25,17 @@ interface DemographicRowProps {
 
 const DemographicRow = ({
   label,
-  onEdit,
+  editing,
+  disabled,
+  hideActions,
+  onEditStart,
   onSave,
+  onReset,
   onClear,
   showClear = false,
   children,
   renderEditing,
 }: DemographicRowProps) => {
-  const [editing, setEditing] = useState(false);
-
-  const handleEdit = () => {
-    setEditing(true);
-    onEdit?.();
-  };
-
-  const handleClear = () => {
-    setEditing(false);
-    onClear?.();
-  };
-  const handleSave = () => {
-    setEditing(false);
-    onSave?.();
-  };
-
   return (
     <>
       <Stack
@@ -59,23 +55,9 @@ const DemographicRow = ({
             <Stack sx={{ width: "100%" }}>
               <Box sx={{ width: "100%", py: 1 }}>{renderEditing}</Box>
 
-              <Stack
-                direction={"row"}
-                spacing={1}
-                justifyContent={"flex-end"}
-                my={1}
-              >
-                <Button
-                  variant="outlined"
-                  color="secondary"
-                  onClick={handleClear}
-                >
-                  Reset Selection
-                </Button>
-                <Button color="secondary" onClick={handleSave}>
-                  Save Selection and Collapse
-                </Button>
-              </Stack>
+              {!hideActions && (
+                <DemographicSaveButton onReset={onReset} onSave={onSave} />
+              )}
               <Divider />
             </Stack>
           )}
@@ -91,7 +73,8 @@ const DemographicRow = ({
             <IconButton
               size="small"
               aria-label={`Edit ${label}`}
-              onClick={handleEdit}
+              disabled={disabled}
+              onClick={onEditStart}
             >
               <EditOutlinedIcon fontSize="small" color="secondary" />
             </IconButton>
@@ -101,7 +84,7 @@ const DemographicRow = ({
               variant="text"
               size="small"
               color="secondary"
-              onClick={handleClear}
+              onClick={onClear}
             >
               Clear all
             </Button>

--- a/src/modules/DemographicsPanel/DemographicSaveButton.tsx
+++ b/src/modules/DemographicsPanel/DemographicSaveButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Button, Stack } from "@mui/material";
+
+interface DemographicSaveButtonProps {
+  onReset: () => void;
+  onSave: () => void;
+}
+
+const DemographicSaveButton = ({
+  onReset,
+  onSave,
+}: DemographicSaveButtonProps) => (
+  <Stack direction={"row"} spacing={1} justifyContent={"flex-end"} my={1}>
+    <Button variant="outlined" color="secondary" onClick={onReset}>
+      Reset Selection
+    </Button>
+    <Button color="secondary" onClick={onSave}>
+      Save Selection and Collapse
+    </Button>
+  </Stack>
+);
+
+export default DemographicSaveButton;

--- a/src/modules/DemographicsPanel/DemographicsPanel.test.tsx
+++ b/src/modules/DemographicsPanel/DemographicsPanel.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ApplicationModeProvider from "@/providers/ApplicationModeProvider";
+import {
+  DEFAULT_QUERY,
+  EMPTY_DEMOGRAPHICS,
+  useQueryBuilderStore,
+} from "@/store/queryBuilderStore";
+import { MAX_AGE_FILTER } from "@/config/rules";
+import DemographicsPanel from "./DemographicsPanel";
+
+const store = () => useQueryBuilderStore.getState();
+const demographics = () => store().queryBuilderJson.demographics;
+
+const female = { concept_id: 8532, name: "Female", category: "Gender" };
+
+const renderPanel = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ApplicationModeProvider>
+        <DemographicsPanel />
+      </ApplicationModeProvider>
+    </QueryClientProvider>,
+  );
+
+const setAgeMin = async (value: string) => {
+  const [minInput] = screen.getAllByRole("spinbutton");
+  await userEvent.clear(minInput);
+  await userEvent.type(minInput, value);
+  await userEvent.keyboard("{Enter}");
+};
+
+describe("DemographicsPanel", () => {
+  describe("first open (freshly added, nothing saved yet)", () => {
+    beforeEach(() => {
+      store().setQueryBuilderJson(DEFAULT_QUERY);
+      store().addDemographics();
+    });
+
+    it("opens every row for editing with a single Save button at the bottom", () => {
+      renderPanel();
+
+      expect(
+        screen.getAllByRole("button", { name: /save selection and collapse/i }),
+      ).toHaveLength(1);
+      expect(
+        screen.queryByRole("button", { name: /reset selection/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /edit age/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("doesn't write to the store until Save is clicked", async () => {
+      renderPanel();
+
+      await setAgeMin("20");
+
+      expect(demographics()?.age).toBeNull();
+    });
+
+    it("commits every field at once and collapses on Save", async () => {
+      renderPanel();
+
+      await setAgeMin("20");
+      await userEvent.click(
+        screen.getByRole("button", { name: /save selection and collapse/i }),
+      );
+
+      expect(demographics()?.age).toEqual([20, MAX_AGE_FILTER]);
+      expect(
+        screen.queryByRole("button", { name: /save selection and collapse/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /edit age/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("after the first save (one row editable at a time)", () => {
+    beforeEach(() => {
+      store().setQueryBuilderJson(DEFAULT_QUERY);
+      store().setDemographics({ ...EMPTY_DEMOGRAPHICS, sex: [female] });
+    });
+
+    it("disables the other rows' Edit buttons while a row is being edited", async () => {
+      renderPanel();
+
+      await userEvent.click(screen.getByRole("button", { name: /edit age/i }));
+
+      expect(screen.getByRole("button", { name: /edit sex/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /edit race/i })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /reset selection/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("Reset Selection discards the draft without writing to the store", async () => {
+      renderPanel();
+
+      await userEvent.click(screen.getByRole("button", { name: /edit age/i }));
+      await setAgeMin("40");
+      await userEvent.click(
+        screen.getByRole("button", { name: /reset selection/i }),
+      );
+
+      expect(demographics()?.age).toBeNull();
+      expect(
+        screen.getByRole("button", { name: /edit sex/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("Save Selection and Collapse commits only the field that was edited", async () => {
+      renderPanel();
+
+      await userEvent.click(screen.getByRole("button", { name: /edit age/i }));
+      await setAgeMin("30");
+      await userEvent.click(
+        screen.getByRole("button", { name: /save selection and collapse/i }),
+      );
+
+      expect(demographics()?.age).toEqual([30, MAX_AGE_FILTER]);
+      expect(demographics()?.sex).toEqual([female]);
+    });
+
+    it("Clear all on a different row commits immediately and survives a later Save elsewhere", async () => {
+      renderPanel();
+
+      await userEvent.click(screen.getByRole("button", { name: /edit age/i }));
+      await setAgeMin("30");
+
+      await userEvent.click(screen.getByRole("button", { name: /clear all/i }));
+      expect(demographics()?.sex).toEqual([]);
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /save selection and collapse/i }),
+      );
+      expect(demographics()?.age).toEqual([30, MAX_AGE_FILTER]);
+      expect(demographics()?.sex).toEqual([]);
+    });
+  });
+});

--- a/src/modules/DemographicsPanel/DemographicsPanel.tsx
+++ b/src/modules/DemographicsPanel/DemographicsPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { FormProvider } from "react-hook-form";
 import {
   Box,
+  Button,
   Collapse,
   IconButton,
   Stack,
@@ -11,15 +13,13 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AccordionExpandIcon from "@/components/AccordionExpandIcon";
-import {
-  DemographicConceptField,
-  DemographicDomain,
-} from "@/config/demographics";
+import { DemographicDomain } from "@/config/demographics";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
 import Title from "@/components/Title";
 import DemographicAgeSection from "./DemographicAgeSection";
 import DemographicCheckboxSection from "./DemographicCheckboxSection";
 import DemographicLocationSection from "./DemographicLocationSection";
+import useDemographicFieldEditing from "./useDemographicFieldEditing";
 import {
   formatAgeSummary,
   formatConceptCountSummary,
@@ -36,21 +36,13 @@ const DemographicsPanel = ({
 }: {
   initialExpand?: boolean;
 }) => {
-  const {
-    demographics,
-    remove,
-    toggleConcept,
-    setConcept,
-    clearConcept,
-    selectedDatasets,
-  } = useQueryBuilder((qb) => ({
-    demographics: qb.queryBuilderJson.demographics,
-    remove: qb.removeDemographics,
-    toggleConcept: qb.toggleDemographicsConcept,
-    setConcept: qb.setDemographicsConcept,
-    clearConcept: qb.clearDemographicsConcept,
-    selectedDatasets: qb.selectedDatasets,
-  }));
+  const { demographics, setDemographics, remove, selectedDatasets } =
+    useQueryBuilder((qb) => ({
+      demographics: qb.queryBuilderJson.demographics,
+      setDemographics: qb.setDemographics,
+      remove: qb.removeDemographics,
+      selectedDatasets: qb.selectedDatasets,
+    }));
   const user = useUserDataStore((s) => s.user);
   const { queryBuilderUseLocation } = useFeatures();
 
@@ -60,6 +52,11 @@ const DemographicsPanel = ({
   const location = demographics?.location ?? null;
 
   const [expanded, setExpanded] = useState(initialExpand);
+
+  const { form, allOpen, save, propsFor } = useDemographicFieldEditing(
+    demographics,
+    setDemographics,
+  );
 
   const summary = [
     formatAgeSummary(age),
@@ -142,35 +139,37 @@ const DemographicsPanel = ({
       </Stack>
 
       <Collapse in={expanded}>
-        <DemographicAgeSection />
+        <FormProvider {...form}>
+          <DemographicAgeSection {...propsFor("age")} />
 
-        <DemographicCheckboxSection
-          label="Sex"
-          options={sexConcepts ?? []}
-          selected={sex}
-          onToggle={(concept, selected) =>
-            toggleConcept(DemographicConceptField.Sex, concept, selected)
-          }
-          onSetAll={(concepts) =>
-            setConcept(DemographicConceptField.Sex, concepts)
-          }
-          onClear={() => clearConcept(DemographicConceptField.Sex)}
-        />
+          <DemographicCheckboxSection
+            label="Sex"
+            field="sex"
+            options={sexConcepts ?? []}
+            selected={sex}
+            {...propsFor("sex")}
+          />
 
-        <DemographicCheckboxSection
-          label="Race"
-          options={raceConcepts ?? []}
-          selected={race}
-          onToggle={(concept, selected) =>
-            toggleConcept(DemographicConceptField.Race, concept, selected)
-          }
-          onSetAll={(concepts) =>
-            setConcept(DemographicConceptField.Race, concepts)
-          }
-          onClear={() => clearConcept(DemographicConceptField.Race)}
-        />
+          <DemographicCheckboxSection
+            label="Race"
+            field="race"
+            options={raceConcepts ?? []}
+            selected={race}
+            {...propsFor("race")}
+          />
 
-        {queryBuilderUseLocation && <DemographicLocationSection />}
+          {queryBuilderUseLocation && (
+            <DemographicLocationSection {...propsFor("location")} />
+          )}
+
+          {allOpen && (
+            <Stack direction="row" justifyContent="flex-end" sx={{ mt: 1 }}>
+              <Button color="secondary" onClick={save}>
+                Save Selection and Collapse
+              </Button>
+            </Stack>
+          )}
+        </FormProvider>
       </Collapse>
     </Box>
   );

--- a/src/modules/DemographicsPanel/useDemographicFieldEditing.ts
+++ b/src/modules/DemographicsPanel/useDemographicFieldEditing.ts
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { EMPTY_DEMOGRAPHICS } from "@/store/queryBuilderStore";
+import { Demographics } from "@/types/rules";
+import { DemographicRowActionProps } from "./DemographicRow";
+
+type DemographicField = keyof Demographics;
+
+const isDemographicsEmpty = (d?: Demographics) =>
+  !d ||
+  (d.age === null &&
+    d.sex.length === 0 &&
+    d.race.length === 0 &&
+    d.location === null);
+
+const useDemographicFieldEditing = (
+  demographics: Demographics | undefined,
+  setDemographics: (demographics: Demographics) => void,
+) => {
+  const form = useForm<Demographics>({
+    defaultValues: demographics ?? EMPTY_DEMOGRAPHICS,
+  });
+
+  const [activeField, setActiveField] = useState<DemographicField | null>(
+    null,
+  );
+  const [allOpen, setAllOpen] = useState(() =>
+    isDemographicsEmpty(demographics),
+  );
+
+  const save = form.handleSubmit((values) => {
+    setDemographics(values);
+    setActiveField(null);
+    setAllOpen(false);
+  });
+
+  const propsFor = (field: DemographicField): DemographicRowActionProps => ({
+    editing: allOpen || activeField === field,
+    disabled: !allOpen && activeField !== null && activeField !== field,
+    hideActions: allOpen,
+    onEditStart: () => {
+      const current = demographics ?? EMPTY_DEMOGRAPHICS;
+      form.resetField(field, { defaultValue: current[field] });
+      setActiveField(field);
+    },
+    onSave: allOpen
+      ? save
+      : () => {
+          const current = demographics ?? EMPTY_DEMOGRAPHICS;
+          setDemographics({ ...current, [field]: form.getValues(field) });
+          setActiveField(null);
+        },
+    onReset: () => {
+      const current = demographics ?? EMPTY_DEMOGRAPHICS;
+      form.resetField(field, { defaultValue: current[field] });
+      setActiveField(null);
+    },
+    onClear: () => {
+      const current = demographics ?? EMPTY_DEMOGRAPHICS;
+      setDemographics({ ...current, [field]: EMPTY_DEMOGRAPHICS[field] });
+    },
+  });
+
+  return { form, allOpen, save, propsFor };
+};
+
+export default useDemographicFieldEditing;

--- a/src/store/queryBuilderStore.demographics.test.ts
+++ b/src/store/queryBuilderStore.demographics.test.ts
@@ -1,14 +1,12 @@
 import { Concept } from "@/types/api";
 import {
   DEFAULT_QUERY,
+  EMPTY_DEMOGRAPHICS,
   useQueryBuilderStore,
 } from "@/store/queryBuilderStore";
 import { useFeatureFlagsStore } from "@/store/featureFlagsStore";
 import { FeatureFlag, FeatureName } from "@/types/features";
-import {
-  DemographicConceptField,
-  DemographicDomain,
-} from "@/config/demographics";
+import { DemographicDomain } from "@/config/demographics";
 
 const concept = (
   concept_id: number,
@@ -55,74 +53,37 @@ describe("queryBuilderStore demographics", () => {
     expect(demographics()).toBeUndefined();
   });
 
-  it("setDemographicsAge writes the age range into the block", () => {
-    store().addDemographics();
-    store().setDemographicsAge([18, 65]);
-    expect(demographics()?.age).toEqual([18, 65]);
-  });
-
-  it("setDemographicsLocation writes and clears the location without touching age", () => {
-    store().addDemographics();
-    store().setDemographicsAge([18, 65]);
-
+  it("setDemographics writes the whole block in one go", () => {
     const location = { lat: 51.5, lon: -0.1, radius: 50000, address: "London" };
-    store().setDemographicsLocation(location);
-    expect(demographics()?.location).toEqual(location);
-    expect(demographics()?.age).toEqual([18, 65]);
+    store().setDemographics({
+      age: [18, 65],
+      sex: [female, male],
+      race: [white],
+      location,
+    });
 
-    store().setDemographicsLocation(null);
-    expect(demographics()?.location).toBeNull();
-    expect(demographics()?.age).toEqual([18, 65]);
+    expect(demographics()).toEqual({
+      age: [18, 65],
+      sex: [female, male],
+      race: [white],
+      location,
+    });
   });
 
-  it("toggleDemographicsConcept adds and removes sex without duplicating", () => {
-    store().toggleDemographicsConcept(DemographicConceptField.Sex, female, true);
-    store().toggleDemographicsConcept(DemographicConceptField.Sex, female, true);
-    expect(demographics()?.sex).toEqual([female]);
+  it("setDemographics replaces the previous block rather than merging", () => {
+    store().setDemographics({ ...EMPTY_DEMOGRAPHICS, age: [18, 65] });
+    store().setDemographics({ ...EMPTY_DEMOGRAPHICS, race: [white, black] });
 
-    store().toggleDemographicsConcept(DemographicConceptField.Sex, male, true);
-    expect(demographics()?.sex).toHaveLength(2);
-
-    store().toggleDemographicsConcept(DemographicConceptField.Sex, female, false);
-    expect(demographics()?.sex).toEqual([male]);
-  });
-
-  it("toggleDemographicsConcept adds and removes race without duplicating", () => {
-    store().toggleDemographicsConcept(DemographicConceptField.Race, white, true);
-    store().toggleDemographicsConcept(DemographicConceptField.Race, white, true);
-    expect(demographics()?.race).toEqual([white]);
-
-    store().toggleDemographicsConcept(DemographicConceptField.Race, black, true);
-    expect(demographics()?.race).toHaveLength(2);
-
-    store().toggleDemographicsConcept(DemographicConceptField.Race, white, false);
-    expect(demographics()?.race).toEqual([black]);
-  });
-
-  it("setDemographicsConcept replaces the whole list (select all)", () => {
-    store().toggleDemographicsConcept(DemographicConceptField.Race, white, true);
-    store().setDemographicsConcept(DemographicConceptField.Race, [white, black]);
-    expect(demographics()?.race).toEqual([white, black]);
-  });
-
-  it("clearDemographicsConcept empties sex without touching age", () => {
-    store().setDemographicsAge([0, 30]);
-    store().toggleDemographicsConcept(DemographicConceptField.Sex, female, true);
-    store().clearDemographicsConcept(DemographicConceptField.Sex);
-    expect(demographics()?.sex).toEqual([]);
-    expect(demographics()?.age).toEqual([0, 30]);
-  });
-
-  it("clearDemographicsConcept empties race without touching sex", () => {
-    store().toggleDemographicsConcept(DemographicConceptField.Sex, female, true);
-    store().toggleDemographicsConcept(DemographicConceptField.Race, white, true);
-    store().clearDemographicsConcept(DemographicConceptField.Race);
-    expect(demographics()?.race).toEqual([]);
-    expect(demographics()?.sex).toEqual([female]);
+    expect(demographics()).toEqual({
+      age: null,
+      sex: [],
+      race: [white, black],
+      location: null,
+    });
   });
 
   it("keeps demographics inside queryBuilderJson (single source of truth)", () => {
-    store().toggleDemographicsConcept(DemographicConceptField.Sex, male, true);
+    store().setDemographics({ ...EMPTY_DEMOGRAPHICS, sex: [male] });
     expect(store().queryBuilderJson.demographics?.sex).toEqual([male]);
   });
 
@@ -133,12 +94,12 @@ describe("queryBuilderStore demographics", () => {
     });
 
     it("is valid with a demographic age set and no rules", () => {
-      store().setDemographicsAge([50, 80]);
+      store().setDemographics({ ...EMPTY_DEMOGRAPHICS, age: [50, 80] });
       expect(isValid()).toBe(true);
     });
 
     it("is valid with a demographic sex set and no rules", () => {
-      store().toggleDemographicsConcept(DemographicConceptField.Sex, female, true);
+      store().setDemographics({ ...EMPTY_DEMOGRAPHICS, sex: [female] });
       expect(isValid()).toBe(true);
     });
 
@@ -148,15 +109,15 @@ describe("queryBuilderStore demographics", () => {
     });
 
     it("becomes invalid again once demographics are cleared", () => {
-      store().setDemographicsAge([50, 80]);
+      store().setDemographics({ ...EMPTY_DEMOGRAPHICS, age: [50, 80] });
       expect(isValid()).toBe(true);
 
-      store().setDemographicsAge(null);
+      store().setDemographics({ ...EMPTY_DEMOGRAPHICS, age: null });
       expect(isValid()).toBe(false);
     });
 
     it("becomes invalid when the whole block is removed", () => {
-      store().toggleDemographicsConcept(DemographicConceptField.Sex, female, true);
+      store().setDemographics({ ...EMPTY_DEMOGRAPHICS, sex: [female] });
       expect(isValid()).toBe(true);
 
       store().removeDemographics();
@@ -167,7 +128,7 @@ describe("queryBuilderStore demographics", () => {
   it("stays invalid with demographics set when the flag is off", () => {
     setDemographicRuleFlag(false);
     store().setQueryBuilderJson(DEFAULT_QUERY);
-    store().setDemographicsAge([50, 80]);
+    store().setDemographics({ ...EMPTY_DEMOGRAPHICS, age: [50, 80] });
     expect(isValid()).toBe(false);
   });
 });

--- a/src/store/queryBuilderStore.ts
+++ b/src/store/queryBuilderStore.ts
@@ -8,7 +8,6 @@ import {
   RuleGroupType,
   RuleNodeType,
   Demographics,
-  GeoRadiusLocation,
 } from "@/types/rules";
 import {
   buildIndexFromModel,
@@ -29,8 +28,7 @@ import { UniqueIdentifier } from "@dnd-kit/core";
 import { removeFalseKeys } from "@/utils/numbers";
 import { EXAMPLE_1, NO_QUERY } from "@/config/queryExamples";
 import { DatasetErrors } from "@/utils/datasets";
-import { Collection, Concept } from "@/types/api";
-import { DemographicConceptField } from "@/config/demographics";
+import { Collection } from "@/types/api";
 import { FeatureName } from "@/types/features";
 import { useFeatureFlagsStore } from "@/store/featureFlagsStore";
 import { intersection } from "lodash";
@@ -62,23 +60,12 @@ export const Creators: Record<string, NodeFactory> = {
 export const DEFAULT_QUERY: RuleGroupType =
   process.env.NEXT_PUBLIC_USE_EXAMPLE_QUERY === "true" ? EXAMPLE_1 : NO_QUERY;
 
-const EMPTY_DEMOGRAPHICS: Demographics = {
+export const EMPTY_DEMOGRAPHICS: Demographics = {
   age: null,
   sex: [],
   race: [],
   location: null,
 };
-
-const withDemographics = (
-  qb: RuleGroupType,
-  updater: (d: Demographics) => Demographics,
-): RuleGroupType => ({
-  ...qb,
-  demographics: updater(qb.demographics ?? EMPTY_DEMOGRAPHICS),
-});
-
-const withoutConcept = (concepts: Concept[], concept: Concept): Concept[] =>
-  concepts.filter((c) => c.concept_id !== concept.concept_id);
 
 export interface QueryBuilderStoreState {
   queryName: string;
@@ -135,18 +122,7 @@ export interface QueryBuilderStoreState {
 
   addDemographics: () => void;
   removeDemographics: () => void;
-  setDemographicsAge: (age: [number, number] | null) => void;
-  setDemographicsLocation: (location: GeoRadiusLocation | null) => void;
-  toggleDemographicsConcept: (
-    field: DemographicConceptField,
-    concept: Concept,
-    selected: boolean,
-  ) => void;
-  setDemographicsConcept: (
-    field: DemographicConceptField,
-    concepts: Concept[],
-  ) => void;
-  clearDemographicsConcept: (field: DemographicConceptField) => void;
+  setDemographics: (demographics: Demographics) => void;
 
   queryAsText: string;
   getQueryFromText: (
@@ -406,45 +382,9 @@ const state: StateCreator<QueryBuilderStoreState> = (set, get) => ({
     const { queryBuilderJson, setQueryBuilderJson } = get();
     setQueryBuilderJson({ ...queryBuilderJson, demographics: undefined }, true);
   },
-  setDemographicsAge: (age) => {
+  setDemographics: (demographics) => {
     const { queryBuilderJson, setQueryBuilderJson } = get();
-    setQueryBuilderJson(
-      withDemographics(queryBuilderJson, (d) => ({ ...d, age })),
-      true,
-    );
-  },
-  setDemographicsLocation: (location) => {
-    const { queryBuilderJson, setQueryBuilderJson } = get();
-    setQueryBuilderJson(
-      withDemographics(queryBuilderJson, (d) => ({ ...d, location })),
-      true,
-    );
-  },
-  toggleDemographicsConcept: (field, concept, selected) => {
-    const { queryBuilderJson, setQueryBuilderJson } = get();
-    setQueryBuilderJson(
-      withDemographics(queryBuilderJson, (d) => ({
-        ...d,
-        [field]: selected
-          ? [...withoutConcept(d[field], concept), concept]
-          : withoutConcept(d[field], concept),
-      })),
-      true,
-    );
-  },
-  setDemographicsConcept: (field, concepts) => {
-    const { queryBuilderJson, setQueryBuilderJson } = get();
-    setQueryBuilderJson(
-      withDemographics(queryBuilderJson, (d) => ({ ...d, [field]: concepts })),
-      true,
-    );
-  },
-  clearDemographicsConcept: (field) => {
-    const { queryBuilderJson, setQueryBuilderJson } = get();
-    setQueryBuilderJson(
-      withDemographics(queryBuilderJson, (d) => ({ ...d, [field]: [] })),
-      true,
-    );
+    setQueryBuilderJson({ ...queryBuilderJson, demographics }, true);
   },
 
   queryAsText: queryToText(DEFAULT_QUERY),


### PR DESCRIPTION
> _Disclaimer: AI (Claude) was used to assist with implementing and documenting the changes in this PR._

## Summary


https://github.com/user-attachments/assets/8f2d20dc-56a6-4ae1-a8df-17278e555fbd



The Demographics panel (Age / Sex / Race / Location rows) used to write straight into `queryBuilderJson.demographics` on every interaction — a checkbox tick, a slider drag, a map pin drop all committed immediately. The "Save Selection and Collapse" button was purely cosmetic: it just collapsed the row, since nothing wired an `onSave` handler up to it.

This PR converts each row to draft-until-save editing via `react-hook-form`, so the demographics JSON block is only written to the store when Save is actually clicked:

- Editing a row now only mutates a local form draft. Reset discards it; Save commits it.
- Only one row can be edited at a time — the other rows' Edit buttons are disabled while a row is open.
- The one exception: the very first time a demographic rule is added (the block is still empty), all rows open at once with a single Save button at the bottom, so a first-time user can set everything in one pass instead of round-tripping through Edit/Save four times.
- "Clear all" (shown on a collapsed row with a value) is unchanged — still an immediate store write, not gated behind Save, since it's a deliberate one-shot action rather than an in-progress edit.

### Decisions worth noting

- **`FormProvider`/`useFormContext<Demographics>()`, not prop-drilled `control`.** Matches the codebase's existing pattern for this shape (`UpdateCollection` owns the form, `CollectionConfig` consumes it via context) rather than threading `control` through every section as a prop.
- **One custom hook (`useDemographicFieldEditing`) instead of a pile of `useState`/helpers in the panel.** It owns the form, which field (if any) is active, and whether every row is forced open; `propsFor(field)` hands back the settled set of coordination props for one row, so `DemographicsPanel.tsx` reads as `<DemographicAgeSection {...propsFor("age")} />` rather than eight named props per row.
- **No resync `useEffect`.** A row's draft only needs to be fresh the moment its edit session starts — `onEditStart` already re-reads the current committed value at that point, and non-active rows never render their form-bound UI, so there's nothing to keep in sync reactively.
- **Per-row Save commits only that field, not the whole form.** The first pass called `form.handleSubmit(values => setDemographics(values))` for every Save, on the assumption that non-active fields' form values always equal their committed values. That assumption breaks for `Controller`s that aren't currently mounted (a row that isn't being edited doesn't render its `Controller`, and `resetField` on an unmounted field doesn't reliably update what `handleSubmit` reads back) — concretely: clear Sex, then edit-and-save Age, and Age's save would silently resubmit Sex's stale pre-clear value, reverting the clear. Caught by `DemographicsPanel.test.tsx`'s "Clear all ... survives a later Save elsewhere" test. Fixed by having per-row Save read and commit only its own field (`form.getValues(field)`) merged onto the latest committed block; the bottom-of-panel global Save (first-open mode) still uses `handleSubmit` since every row's `Controller` is mounted in that mode.
- **Store simplified to one action.** `setDemographicsAge`/`setDemographicsLocation`/`toggleDemographicsConcept`/`setDemographicsConcept`/`clearDemographicsConcept` (and the `withDemographics` helper) are replaced by a single `setDemographics(demographics: Demographics)` — the granular setters existed to support immediate-write editing, which no longer happens.

## Jira

https://hdruk.atlassian.net/browse/DP-1091

## PR Type

- [ ] `feat`
- [x] `refactor`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `test`
- [ ] `perf`

## PR Title Check

`refactor(DP-1091): draft-until-save editing for the demographics panel`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [x] State management changes (hooks/store)
- [x] Test updates
- [ ] Documentation updates

### Files

| File | Change |
|---|---|
| `src/modules/DemographicsPanel/useDemographicFieldEditing.ts` | **new** — owns the shared `useForm<Demographics>()`, which field is active, first-open state, and `propsFor(field)` |
| `src/modules/DemographicsPanel/DemographicsPanel.tsx` | wraps rows in `<FormProvider>`, spreads `propsFor(field)` into each section, renders the bottom Save button while first-open |
| `src/modules/DemographicsPanel/DemographicRow.tsx` | dropped its own `editing` state — now fully controlled; exports the shared `DemographicRowActionProps` type |
| `src/modules/DemographicsPanel/DemographicSaveButton.tsx` | now holds the actual Reset/Save button pair (previously an in-progress, unused duplicate of the row's Edit/Clear controls) |
| `src/modules/DemographicsPanel/DemographicAgeSection.tsx`, `DemographicCheckboxSection.tsx`, `DemographicLocationSection.tsx` | pull `control` via `useFormContext<Demographics>()` instead of taking it as a prop; checkbox toggle/select-all logic now operates on the draft, not the committed store value |
| `src/modules/DemographicsPanel/DemographicConceptSection.tsx` | unused elsewhere in the app; updated to the same controlled-row contract so it isn't left broken |
| `src/store/queryBuilderStore.ts` | five granular demographics actions collapsed into one `setDemographics`; `EMPTY_DEMOGRAPHICS` now exported |
| `src/store/queryBuilderStore.demographics.test.ts` | updated for `setDemographics` |
| `src/modules/DemographicsPanel/DemographicsPanel.test.tsx` | **new** — first-open-all-editable, single-row coordination, Reset/Save/Clear-all behaviour, and the stale-draft regression above |
| `src/modules/DemographicsPanel/DemographicLocationSection.test.tsx` | updated to wrap the section in a local `FormProvider` instead of passing `control` directly |

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [x] `npm run test` passes (247 tests, including 7 new tests in `DemographicsPanel.test.tsx`)
- [x] `npm run build` passes
- [ ] `npm run build-storybook` passes (Storybook is not used in this project)
- [ ] Manual browser walkthrough — not completed in this session (no local login credentials to hand); please exercise the golden path below before merging

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs) — n/a, no routing changes
- [x] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components) — n/a, no API changes
- [x] Side-effectful endpoints are not cached unintentionally — n/a, no API changes
- [x] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

None captured — this session didn't have login credentials for a local walkthrough. See the manual test plan below.

## Risk and Rollback

- Risk level: medium
- Main risk areas:
  - Demographics panel editing flow (Age/Sex/Race/Location) — behaviour change from immediate-write to draft-until-save
  - `setDemographics` replacing the five granular store actions — anything outside this module that called `setDemographicsAge`/`toggleDemographicsConcept`/etc. would break at compile time (grepped repo-wide; nothing else called them)
- Rollback plan:
  - Revert PR — no data migration or persisted-state shape change involved (`Demographics` type is unchanged, only how it gets written)

## Notes for Reviewers

Manual walkthrough worth doing before merge, with `query-builder-use-demographic-rule` (and `query-builder-use-location`) feature flags on:

1. Add a demographic rule — all rows should open at once with one Save button at the bottom; edit a couple of fields and confirm nothing is written to the store until Save is clicked.
2. Click Save — rows collapse to their summaries, one commit.
3. Click Edit on one row — the other rows' Edit icons should be disabled; Reset/Save now appear under that row only.
4. Reset discards the draft; Save commits only that field.
5. Clear all on a different, non-editing row should apply immediately, including while another row is mid-edit — this is the scenario `DemographicsPanel.test.tsx` covers, but worth eyeballing in the real UI too.
