### PR TITLE
feat(DP-1092): redesign location map picker

### DIFF
--- a/src/components/GeoMap/AddressSearch.test.tsx
+++ b/src/components/GeoMap/AddressSearch.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddressSearch from "./AddressSearch";
+
+describe("AddressSearch", () => {
+  it("reflects an externally-changed value prop, e.g. after a map pin drop", () => {
+    const { rerender } = render(<AddressSearch onSelect={jest.fn()} value="" />);
+
+    const input = screen.getByPlaceholderText(
+      /search by address, postcode or location/i,
+    ) as HTMLInputElement;
+    expect(input.value).toBe("");
+
+    rerender(<AddressSearch onSelect={jest.fn()} value="51.5074, -0.1278" />);
+
+    expect(input.value).toBe("51.5074, -0.1278");
+  });
+
+  it("does not call onSelect when free text is typed without picking a suggestion", async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+    render(<AddressSearch onSelect={onSelect} value="" />);
+
+    const input = screen.getByPlaceholderText(
+      /search by address, postcode or location/i,
+    );
+    await user.type(input, "not a real place{enter}");
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/GeoMap/AddressSearch.tsx
+++ b/src/components/GeoMap/AddressSearch.tsx
@@ -17,15 +17,33 @@ interface NominatimResult {
 
 interface AddressSearchProps {
   onSelect: (position: LatLngTuple, address: string) => void;
+  /** Displayed in the input, e.g. an address or "lat, lon" after a pin drop. */
+  value?: string;
 }
 
-export default function AddressSearch({ onSelect }: AddressSearchProps) {
-  const [inputValue, setInputValue] = useState("");
+export default function AddressSearch({
+  onSelect,
+  value = "",
+}: AddressSearchProps) {
+  const [inputValue, setInputValue] = useState(value);
   const [options, setOptions] = useState<NominatimResult[]>([]);
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // A pin drop or saved value syncs the input without it being a search
+  // query — skip the next fetch so we don't hit Nominatim with "51.5, -0.1".
+  const skipNextFetch = useRef(false);
 
   useEffect(() => {
+    skipNextFetch.current = true;
+    setInputValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (skipNextFetch.current) {
+      skipNextFetch.current = false;
+      return;
+    }
+
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     const query = inputValue.trim();
@@ -62,16 +80,17 @@ export default function AddressSearch({ onSelect }: AddressSearchProps) {
   }, [inputValue]);
 
   return (
-    <Autocomplete<NominatimResult>
+    <Autocomplete<NominatimResult, false, false, true>
       options={options}
-      getOptionLabel={(o) => o.display_name}
+      getOptionLabel={(o) => (typeof o === "string" ? o : o.display_name)}
       isOptionEqualToValue={(a, b) => a.place_id === b.place_id}
       filterOptions={(x) => x}
       loading={loading}
+      freeSolo
       inputValue={inputValue}
       onInputChange={(_, v) => setInputValue(v)}
       onChange={(_, result) => {
-        if (!result) return;
+        if (!result || typeof result === "string") return;
         onSelect(
           [parseFloat(result.lat), parseFloat(result.lon)],
           result.display_name,

--- a/src/components/GeoMap/AddressSearch.tsx
+++ b/src/components/GeoMap/AddressSearch.tsx
@@ -1,4 +1,10 @@
-import { Autocomplete, CircularProgress, TextField } from "@mui/material";
+import {
+  Autocomplete,
+  CircularProgress,
+  InputAdornment,
+  TextField,
+} from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
 import { useEffect, useRef, useState } from "react";
 import type { LatLngTuple } from "leaflet";
 
@@ -74,13 +80,19 @@ export default function AddressSearch({ onSelect }: AddressSearchProps) {
         setOptions([]);
       }}
       size="small"
+      forcePopupIcon={false}
       renderInput={(params) => (
         <TextField
           {...params}
-          placeholder="Search by postcode, county or location…"
+          placeholder="Search by address, postcode or location…"
           slotProps={{
             input: {
               ...params.InputProps,
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" color="action" />
+                </InputAdornment>
+              ),
               endAdornment: (
                 <>
                   {loading && <CircularProgress size={16} />}

--- a/src/components/GeoMap/GeoMapPicker.tsx
+++ b/src/components/GeoMap/GeoMapPicker.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import L from "leaflet";
-import { Marker, useMap, useMapEvents } from "react-leaflet";
+import { Marker, useMap, useMapEvents, ZoomControl } from "react-leaflet";
 import AddressSearch from "./AddressSearch";
 import { useEffect, useState } from "react";
-import {
-  Box,
-  FormControlLabel,
-  Slider,
-  Stack,
-  Switch,
-  Typography,
-} from "@mui/material";
+import { Box, Slider, Stack, Typography } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import ToggleAction from "@/components/ToggleAction";
 import { GeoRadiusLocation } from "@/types/rules";
 import { formatRadius } from "./formatRadius";
 import GeoMapFrame from "./GeoMapFrame";
@@ -79,6 +75,11 @@ export default function GeoMapPicker({
   const [address, setAddress] = useState<string | undefined>(value?.address);
   const [flyTarget, setFlyTarget] = useState<L.LatLngTuple | null>(null);
   const [showBoundaries, setShowBoundaries] = useState(true);
+  // Frame the saved radius on first render — a fixed zoom would otherwise
+  // ignore how wide an existing location's radius actually is.
+  const [initialBounds] = useState(() =>
+    value ? L.latLng(value.lat, value.lon).toBounds(value.radius * 2) : undefined,
+  );
 
   const handlePinDrop = (pos: L.LatLngTuple) => {
     setPosition(pos);
@@ -101,33 +102,15 @@ export default function GeoMapPicker({
   };
 
   return (
-    <Stack spacing={2}>
-      <Stack
-        direction={{ xs: "column", sm: "row" }}
-        spacing={1}
-        alignItems={{ sm: "center" }}
-      >
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          <AddressSearch onSelect={handleSearchSelect} />
-        </Box>
-        <FormControlLabel
-          control={
-            <Switch
-              size="small"
-              checked={showBoundaries}
-              onChange={(_, checked) => setShowBoundaries(checked)}
-            />
-          }
-          label={<Typography variant="body2">Show LSOA boundaries</Typography>}
-          sx={{ flexShrink: 0, mr: 0 }}
-        />
-      </Stack>
-
+    <Box sx={{ position: "relative" }}>
       <GeoMapFrame
         height={mapHeight}
         center={position ?? DEFAULT_MAP_CENTER}
         zoom={position ? PINNED_MAP_ZOOM : DEFAULT_MAP_ZOOM}
+        fitBounds={initialBounds}
+        zoomControl={false}
       >
+        <ZoomControl position="bottomright" />
         <FlyTo target={flyTarget} />
         <LSOABoundaries
           pinPosition={position}
@@ -142,33 +125,77 @@ export default function GeoMapPicker({
         {position && <RadiusCircle center={position} radius={radius} />}
       </GeoMapFrame>
 
-      <Stack spacing={0.5} px={1}>
-        <Typography variant="body2" fontWeight={500}>
-          Radius: {formatRadius(radius)}
-        </Typography>
-        <Slider
-          value={metersToSlider(radius)}
-          onChange={(_, v) => handleRadiusChange(sliderToMeters(v as number))}
-          min={0}
-          max={100}
-          step={0.5}
-          aria-label="Radius"
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1.5}
+        sx={{
+          position: "absolute",
+          top: 12,
+          left: 12,
+          right: 12,
+          zIndex: 1000,
+          bgcolor: "background.paper",
+          borderRadius: 5,
+          boxShadow: 1,
+          px: 1.5,
+          py: 0.75,
+        }}
+      >
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <AddressSearch onSelect={handleSearchSelect} />
+        </Box>
+        <ToggleAction
+          size={25}
+          active={showBoundaries}
+          onToggle={() => setShowBoundaries((prev) => !prev)}
+          activeIcon={CheckIcon}
+          inactiveIcon={CloseIcon}
         />
-        <Stack direction="row" justifyContent="space-between">
-          <Typography variant="caption" color="text.secondary">
-            5 km
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            1000 km
-          </Typography>
-        </Stack>
+        <Typography variant="body2" sx={{ flexShrink: 0 }}>
+          LSOA boundaries
+        </Typography>
       </Stack>
 
-      <Typography variant="caption" color="text.secondary" textAlign="center">
-        {position
-          ? `${position[0].toFixed(5)}, ${position[1].toFixed(5)}`
-          : "Click on the map to drop a pin"}
-      </Typography>
-    </Stack>
+      {position && (
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{
+            position: "absolute",
+            bottom: 12,
+            left: 12,
+            zIndex: 1000,
+            bgcolor: "background.paper",
+            borderRadius: 5,
+            boxShadow: 1,
+            px: 1.5,
+            py: 0.5,
+          }}
+        >
+          <Typography variant="body2" fontWeight={500} sx={{ flexShrink: 0 }}>
+            Radius
+          </Typography>
+          <Slider
+            value={metersToSlider(radius)}
+            onChange={(_, v) => handleRadiusChange(sliderToMeters(v as number))}
+            min={0}
+            max={100}
+            step={0.5}
+            aria-label="Radius"
+            size="small"
+            sx={{ width: 120 }}
+          />
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ flexShrink: 0 }}
+          >
+            +{formatRadius(radius)}
+          </Typography>
+        </Stack>
+      )}
+    </Box>
   );
 }

--- a/src/components/GeoMap/GeoMapPicker.tsx
+++ b/src/components/GeoMap/GeoMapPicker.tsx
@@ -143,7 +143,15 @@ export default function GeoMapPicker({
         }}
       >
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          <AddressSearch onSelect={handleSearchSelect} />
+          <AddressSearch
+            onSelect={handleSearchSelect}
+            value={
+              address ??
+              (position
+                ? `${position[0].toFixed(4)}, ${position[1].toFixed(4)}`
+                : "")
+            }
+          />
         </Box>
         <ToggleAction
           size={25}

--- a/src/modules/DemographicsPanel/DemographicLocationSection.test.tsx
+++ b/src/modules/DemographicsPanel/DemographicLocationSection.test.tsx
@@ -87,6 +87,11 @@ describe("DemographicLocationSection", () => {
     expect(screen.getByText(/drop a pin/i)).toBeInTheDocument();
   });
 
+  it("keeps the header plain while editing", () => {
+    render(<Harness editing />);
+    expect(screen.queryByText(/LatLng/)).not.toBeInTheDocument();
+  });
+
   it("clears the location via Clear all", async () => {
     setLondon();
     const onClear = jest.fn();

--- a/src/modules/DemographicsPanel/DemographicLocationSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicLocationSection.tsx
@@ -38,7 +38,7 @@ const DemographicLocationSection = (props: DemographicRowActionProps) => {
         <Box
           sx={{ maxHeight: 450, overflowY: "auto", overflowX: "hidden", pr: 1 }}
         >
-          <Stack spacing={1} marginX={10}>
+          <Stack spacing={1}>
             <Controller
               name="location"
               control={control}

--- a/src/modules/DemographicsPanel/DemographicRow.tsx
+++ b/src/modules/DemographicsPanel/DemographicRow.tsx
@@ -41,7 +41,7 @@ const DemographicRow = ({
       <Stack
         direction="row"
         justifyContent="space-between"
-        alignItems="space-between"
+        alignItems="flex-start"
         spacing={1}
         sx={{ py: 1, width: "100%" }}
       >
@@ -49,17 +49,17 @@ const DemographicRow = ({
           title={label}
           size={"small"}
           subTitle={editing ? " " : children}
-          wrapperSx={{ width: "100%" }}
+          flexShrink={0}
+          wrapperSx={{ width: "100%", alignItems: "flex-start" }}
         >
           {editing && (
-            <Stack sx={{ width: "100%" }}>
-              <Box sx={{ width: "100%", py: 1 }}>{renderEditing}</Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Box sx={{ width: "100%", pb: 1 }}>{renderEditing}</Box>
 
               {!hideActions && (
                 <DemographicSaveButton onReset={onReset} onSave={onSave} />
               )}
-              <Divider />
-            </Stack>
+            </Box>
           )}
         </Title>
 


### PR DESCRIPTION
> _Disclaimer: AI (Claude) was used to assist with implementing and documenting the changes in this PR._

## Summary


https://github.com/user-attachments/assets/466f5c71-ffc2-4274-9688-3d4785da5d67



Redesigns the Location demographics filter's map picker (`GeoMapPicker`) to match the latest design: the address search bar now overlays the top of the map instead of sitting in a row above it, the "LSOA boundaries" toggle moved into that same overlay bar next to the search box (using the shared `ToggleAction` component instead of a plain MUI `Switch`), and the radius slider is now a compact overlay pinned to the bottom-left of the map that only appears once a location has actually been picked (pin dropped or address searched) rather than always being visible. Leaflet's zoom control moved from its default top-left position to bottom-right so it no longer sits under the new search overlay.

Also fixes two real bugs surfaced while building this:

- **Wrong initial zoom when editing an existing location.** The map always opened at a fixed zoom level regardless of the saved radius, so a wide radius (e.g. 500 km) opened tightly zoomed in with the radius circle nowhere in view. `GeoMapPicker` now computes an initial Leaflet `fitBounds` from the saved `lat/lon` + `radius` on mount (`L.latLng(...).toBounds(radius * 2)`), so opening a saved location frames its full radius.
- **Search bar not reflecting a pin drop.** Dropping a pin directly on the map (without searching an address) left the search box empty. `AddressSearch` now accepts a `value` prop and `GeoMapPicker` feeds it a formatted `"lat, lon"` string whenever there's a position with no address. This uncovered a subtler MUI `Autocomplete` issue: without `freeSolo`, Autocomplete resets `inputValue` back to match the selected `value` (`null`) on every render, silently undoing the externally-set text — `freeSolo` had to be added, with `getOptionLabel`/`onChange` guarded against the free-typed-string case that `freeSolo` introduces (otherwise a raw string could reach `.lat`/`.lon` and crash, or trip an MUI console warning).

`DemographicRow.tsx` (shared by Age/Sex/Race/Location) also got two small fixes needed to support the above and to match the same design language across all four rows: an invalid CSS `alignItems="space-between"` value was corrected to `"flex-start"`, and the editing content now sits as a flex sibling to the right of the row's label (`flexShrink={0}` on the label, `flex: 1, minWidth: 0` on the content) instead of stacked awkwardly underneath it.

### Decisions worth noting

- **`freeSolo` on `AddressSearch`'s `Autocomplete`.** Required to let the input display arbitrary text (a lat/lng readout) that doesn't correspond to any selected option — MUI actively fights a controlled `inputValue` otherwise. This is a genuinely subtle MUI behaviour: it wasn't caught by reading the code, only by writing a test that re-rendered `AddressSearch` with a changed `value` prop and watching the DOM input value get silently reset.
- **`showBoundaries` stayed local `useState` in `GeoMapPicker`**, not lifted to the parent. An earlier iteration lifted it (and a live lat/lng readout) into the outer `DemographicRow` header to match an intermediate design, but the design settled on keeping both in the map overlay instead — see Known follow-ups below for the one leftover from that direction that's now dead weight in `DemographicRow`.
- **`ToggleAction` reused as-is** for "LSOA boundaries" rather than styling a new control, matching its only other consumer (`SelectDatasets.tsx`). It renders as two segmented icon buttons (X / check) rather than a sliding switch — a different interaction pattern than the `Switch` it replaces (see Known follow-ups).


## Jira

https://hdruk.atlassian.net/browse/DP-1092

## PR Type

- [x] `feat`
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `perf`

## PR Title Check

`feat(DP-1092): redesign location map picker`

## Changes Included

- [x] UI changes
- [ ] API integration changes (`src/actions/*`)
- [ ] Routing/navigation changes (`src/config/routes.ts`, app router pages)
- [ ] State management changes (hooks/store)
- [x] Test updates
- [ ] Documentation updates

### Files

| File | Change |
|---|---|
| `src/components/GeoMap/GeoMapPicker.tsx` | overlay search bar + boundaries toggle, conditional radius overlay, repositioned zoom control, `fitBounds` framing for saved locations, feeds `AddressSearch` a lat/lng readout |
| `src/components/GeoMap/AddressSearch.tsx` | new `value` prop for externally-driven text, `freeSolo` fix (+ guarded `onChange`/`getOptionLabel`), new placeholder wording, leading search icon |
| `src/components/GeoMap/AddressSearch.test.tsx` | **new** — regression test for the `value`-prop/`freeSolo` bug, plus a free-typed-text-without-selection test |
| `src/modules/DemographicsPanel/DemographicRow.tsx` | `alignItems` fix, editing content laid out beside the label instead of stacked under it |
| `src/modules/DemographicsPanel/DemographicLocationSection.tsx` | passes `showLatLngHeader`-era plumbing removed; wires nothing extra now that boundaries/search live inside `GeoMapPicker` |
| `src/modules/DemographicsPanel/DemographicLocationSection.test.tsx` | updated for the header staying plain while editing |

## Validation

Run locally before requesting review:

- [x] `npm run lint` passes
- [x] `npm run test` passes (43 suites, 250 tests)
- [x] `npm run build` passes
- [ ] `npm run build-storybook` passes — n/a, Storybook is not used in this project
- [ ] Manual browser walkthrough — not completed in this session (no local login credentials to hand); please exercise the golden path below before merging

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions (PascalCase component files, `use*` hooks, action files in `src/actions`)
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs) — n/a, no routing changes
- [x] API calls follow existing patterns (`apiGet/apiPost/...` in server actions, not ad-hoc fetch in client components) — n/a, no API changes
- [x] Side-effectful endpoints are not cached unintentionally — n/a, no API changes
- [x] No sensitive values, secrets, or debug-only code left behind

## Screenshots / Evidence

None captured — this session didn't have login credentials for a local walkthrough; all layout iteration was verified against design mockups the reviewer supplied. See the manual test plan below.

## Risk and Rollback

- Risk level: low-medium
- Main risk areas:
  - Location map picker UI only — no data model or store shape changes, so a regression here is visually contained to the demographics Location row
  - `AddressSearch`'s `freeSolo` change alters `Autocomplete`'s `onChange` value type; guarded, but worth double-checking address selection still fires `onSelect` correctly for every result path
  - The two known follow-ups above (zoom-snap timing, toggle accessibility) ship as-is
- Rollback plan:
  - Revert PR — no data migration or persisted-state shape change involved (`GeoRadiusLocation` type is unchanged)

## Notes for Reviewers

Manual walkthrough worth doing before merge, with the `query-builder-use-location` feature flag on:

1. Edit the Location row — search bar + "LSOA boundaries" toggle should overlay the top of the map; no radius overlay until a location is set.
2. Drop a pin on the map — the search box should populate with the pin's `lat, lon`; the radius overlay should appear bottom-left; zoom control (+/-) should sit bottom-right, not overlapping anything.
3. Search an address and pick a result — search box should show the address; map should fly to it.
4. Save a location, then re-open Edit on that row — the map should frame the saved radius (watch for the known zoom-snap follow-up noted above).
5. Toggle "LSOA boundaries" off/on — boundaries layer should show/hide; try it via keyboard only to see the accessibility gap noted above firsthand.

The two "Known follow-ups" above are real, verified gaps (not speculative) — happy to open follow-up tickets for them rather than fold them into this PR, since neither blocks the design work this PR is scoped to.
