### PR TITLE
feat(DP-1094): truncate addresses in query preview

### DIFF
--- a/src/components/GeoMap/__tests__/geoUtils.test.ts
+++ b/src/components/GeoMap/__tests__/geoUtils.test.ts
@@ -1,12 +1,59 @@
 import { haversineMetres } from "../haversine";
 import { pointInPolygon } from "../pointInPolygon";
 import { formatRadius } from "../formatRadius";
+import { extractPostcode } from "../extractPostcode";
 
 describe("formatRadius", () => {
   it("formats metres as kilometres to one decimal place", () => {
     expect(formatRadius(50000)).toBe("50.0 km");
     expect(formatRadius(5000)).toBe("5.0 km");
     expect(formatRadius(1234)).toBe("1.2 km");
+  });
+});
+
+describe("extractPostcode", () => {
+  it("extracts the postcode from a realistic Nominatim display_name", () => {
+    expect(
+      extractPostcode(
+        "10 Downing Street, Westminster, London, Greater London, England, SW1A 2AA, United Kingdom",
+      ),
+    ).toBe("SW1A 2AA");
+  });
+
+  it("returns null when no postcode-shaped substring exists", () => {
+    expect(
+      extractPostcode("Buckingham Palace, London, England, United Kingdom"),
+    ).toBeNull();
+  });
+
+  it("matches a postcode at the start of the string", () => {
+    expect(extractPostcode("SW1A 2AA, Westminster, London")).toBe(
+      "SW1A 2AA",
+    );
+  });
+
+  it("matches a postcode at the end with no trailing comma", () => {
+    expect(extractPostcode("Greater London, England, SW1A 2AA")).toBe(
+      "SW1A 2AA",
+    );
+  });
+
+  it("is case-insensitive on input and upper-cases the output", () => {
+    expect(
+      extractPostcode("10 downing street, london, sw1a 2aa, united kingdom"),
+    ).toBe("SW1A 2AA");
+  });
+
+  it("normalises irregular spacing", () => {
+    expect(extractPostcode("England, SW1A2AA, United Kingdom")).toBe(
+      "SW1A 2AA",
+    );
+  });
+
+  it("prefers the last match when an earlier postcode-shaped substring exists", () => {
+    expect(
+      extractPostcode("AA1 1AA Business Park, Leeds, LS1 4DY, United Kingdom"),
+    ).toBe("LS1 4DY");
   });
 });
 

--- a/src/components/GeoMap/extractPostcode.ts
+++ b/src/components/GeoMap/extractPostcode.ts
@@ -1,0 +1,12 @@
+const UK_POSTCODE_PATTERN = /\b([A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2})\b/gi;
+
+// Nominatim's `display_name` always places the real postcode just before the
+// country, so taking the last match avoids false positives from
+// postcode-shaped substrings earlier in the string (e.g. in a building name).
+export const extractPostcode = (address: string): string | null => {
+  const matches = [...address.matchAll(UK_POSTCODE_PATTERN)];
+  if (matches.length === 0) return null;
+
+  const compact = matches[matches.length - 1][0].toUpperCase().replace(/\s+/g, "");
+  return `${compact.slice(0, -3)} ${compact.slice(-3)}`;
+};

--- a/src/components/GeoMap/index.ts
+++ b/src/components/GeoMap/index.ts
@@ -1,1 +1,2 @@
 export { formatRadius } from "./formatRadius";
+export { extractPostcode } from "./extractPostcode";

--- a/src/modules/DemographicsPanel/DemographicLocationSection.test.tsx
+++ b/src/modules/DemographicsPanel/DemographicLocationSection.test.tsx
@@ -73,11 +73,28 @@ describe("DemographicLocationSection", () => {
     expect(screen.getByText("Any")).toBeInTheDocument();
   });
 
-  it("summarises a set location", () => {
+  it("summarises a set location, falling back to the full address when no postcode can be extracted", () => {
     setLondon();
     render(<Harness />);
     expect(
       screen.getByText("Within 50.0 km of London"),
+    ).toBeInTheDocument();
+  });
+
+  it("truncates the address to its postcode when the address contains one", () => {
+    store().setDemographics({
+      ...(store().queryBuilderJson.demographics ?? EMPTY_DEMOGRAPHICS),
+      location: {
+        lat: 51.5,
+        lon: -0.1,
+        radius: 50000,
+        address:
+          "10 Downing Street, Westminster, London, Greater London, England, SW1A 2AA, United Kingdom",
+      },
+    });
+    render(<Harness />);
+    expect(
+      screen.getByText("Within 50.0 km of SW1A 2AA"),
     ).toBeInTheDocument();
   });
 

--- a/src/modules/DemographicsPanel/DemographicLocationSection.tsx
+++ b/src/modules/DemographicsPanel/DemographicLocationSection.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import { Controller, useFormContext } from "react-hook-form";
 import { Box, Chip, Skeleton, Stack, Typography } from "@mui/material";
 import useQueryBuilder from "@/hooks/useQueryBuilder";
-import { formatRadius } from "@/components/GeoMap";
+import { extractPostcode, formatRadius } from "@/components/GeoMap";
 import { locationGuidance } from "@/config/demographics";
 import { Demographics } from "@/types/rules";
 import DemographicRow, { DemographicRowActionProps } from "./DemographicRow";
@@ -24,6 +24,7 @@ const DemographicLocationSection = (props: DemographicRowActionProps) => {
 
   const summaryLabel = location
     ? `Within ${formatRadius(location.radius)} of ${
+        (location.address && extractPostcode(location.address)) ??
         location.address ??
         `(${location.lat.toFixed(4)}, ${location.lon.toFixed(4)})`
       }`

--- a/src/utils/__tests__/queryBuilder.test.ts
+++ b/src/utils/__tests__/queryBuilder.test.ts
@@ -337,7 +337,26 @@ describe("queryToText — demographics", () => {
     ).toBe("People between 18 and 65");
   });
 
-  it("phrases a location with an address", () => {
+  it("phrases a location with an address, truncated to the postcode", () => {
+    expect(
+      queryToText(
+        demographicsOnly({
+          age: null,
+          sex: [],
+          race: [],
+          location: {
+            lat: 51.5,
+            lon: -0.1,
+            radius: 50000,
+            address:
+              "10 Downing Street, Westminster, London, Greater London, England, SW1A 2AA, United Kingdom",
+          },
+        }),
+      ),
+    ).toBe("People living within 50.0 km of SW1A 2AA");
+  });
+
+  it("falls back to the full address when no postcode can be extracted", () => {
     expect(
       queryToText(
         demographicsOnly({
@@ -379,11 +398,12 @@ describe("queryToText — demographics", () => {
             lat: 51.5,
             lon: -0.1,
             radius: 50000,
-            address: "London",
+            address:
+              "10 Downing Street, Westminster, London, Greater London, England, SW1A 2AA, United Kingdom",
           },
         }),
       ),
-    ).toBe("Males over 85 living within 50.0 km of London");
+    ).toBe("Males over 85 living within 50.0 km of SW1A 2AA");
   });
 
   it("folds demographics into the concept-rule text", () => {

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -16,7 +16,7 @@ import {
 } from "@/utils/rules";
 import { MAX_AGE_FILTER, MIN_AGE_FILTER } from "@/config/rules";
 import { UniqueIdentifier } from "@dnd-kit/core";
-import { formatRadius } from "@/components/GeoMap";
+import { extractPostcode, formatRadius } from "@/components/GeoMap";
 import { getDomainPhrase } from "./omop";
 
 type Piece = { verb?: string | null; text: string };
@@ -429,7 +429,9 @@ const formatLocationPhrase = (
 ): string | null => {
   if (!location) return null;
   const { lat, lon, radius, address } = location;
-  const place = address ?? `(${lat.toFixed(4)}, ${lon.toFixed(4)})`;
+  const place = address
+    ? (extractPostcode(address) ?? address)
+    : `(${lat.toFixed(4)}, ${lon.toFixed(4)})`;
   return `living within ${formatRadius(radius)} of ${place}`;
 };
 


### PR DESCRIPTION
## Summary

Truncates search-bar-entered addresses to just the postcode wherever they're shown as text — the query preview sentence and the demographics panel's Location summary chip — falling back to the full address if no postcode can be parsed out of it. Pin-dropped locations (which store no address) are unaffected.

## Jira

https://hdruk.atlassian.net/browse/DP-1094

## PR Type

- [x] `feat`

## PR Title Check

- [x] `feat(DP-1094): truncate addresses in query preview`

## Changes Included

- [x] UI changes
- [x] Test updates

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run build` passes

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts` (no scattered hard-coded dashboard URLs) — n/a, no routing changes
- [x] API calls follow existing patterns — n/a, no API calls added
- [x] Side-effectful endpoints are not cached unintentionally — n/a
- [x] No sensitive values, secrets, or debug-only code left behind

## Risk and Rollback

- Risk level: low
- Main risk areas:
  - Postcode regex is best-effort (shape-only matching); falls back to the full address if it doesn't match, so it never hides location information.
- Rollback plan:
  - Revert this PR.

## Notes for Reviewers

Stacked on `fix/DP-1093` (PR #491), which is itself stacked on `feat/DP-1092` (PR #489). This PR's diff is limited to the new `extractPostcode` utility and its two call sites.

> This PR was implemented with AI assistance (Claude Code).