### PR TITLE
fix(DP-1098): Race content chips overlap Clear all

### DIFF
--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -11,6 +11,7 @@ export interface TitleProps extends Omit<BoxProps, "title"> {
   wrapperSx?: BoxProps;
   titleOverflow?: "ellipsis" | "scroll" | "wrap" | "visible";
   centerTitleContent?: boolean;
+  subTitleWrap?: boolean;
 }
 
 const Title = ({
@@ -23,6 +24,7 @@ const Title = ({
   wrapperSx,
   titleOverflow = "ellipsis",
   centerTitleContent = false,
+  subTitleWrap = false,
   ...rest
 }: TitleProps) => {
   const titleVariant =
@@ -68,12 +70,14 @@ const Title = ({
       sx={{
         display: "flex",
         overflow: "wrap",
+        ...(subTitleWrap && { minWidth: 0 }),
       }}
       {...wrapperSx}
     >
       <Box
         display="flex"
         alignItems={centerTitleContent ? "center" : "baseline"}
+        sx={subTitleWrap ? { width: "100%", minWidth: 0 } : undefined}
         {...rest}
       >
         <Typography
@@ -94,8 +98,13 @@ const Title = ({
           <Typography
             variant={subTitleVariant}
             component="span"
-            noWrap
-            sx={{ flexShrink: 0, mx: 1 }}
+            noWrap={!subTitleWrap}
+            sx={{
+              mx: 1,
+              ...(subTitleWrap
+                ? { flex: 1, minWidth: 0, whiteSpace: "normal" }
+                : { flexShrink: 0 }),
+            }}
           >
             {subTitle}
           </Typography>

--- a/src/modules/DemographicsPanel/DemographicRow.tsx
+++ b/src/modules/DemographicsPanel/DemographicRow.tsx
@@ -49,6 +49,7 @@ const DemographicRow = ({
           title={label}
           size={"small"}
           subTitle={editing ? " " : children}
+          subTitleWrap
           flexShrink={0}
           wrapperSx={{ width: "100%", alignItems: "flex-start" }}
         >

--- a/src/modules/DemographicsPanel/DemographicRow.tsx
+++ b/src/modules/DemographicsPanel/DemographicRow.tsx
@@ -49,7 +49,7 @@ const DemographicRow = ({
           title={label}
           size={"small"}
           subTitle={editing ? " " : children}
-          subTitleWrap
+          subTitleWrap={!editing}
           flexShrink={0}
           wrapperSx={{ width: "100%", alignItems: "flex-start" }}
         >


### PR DESCRIPTION
## Summary

Fixes the Race (and latently, Sex) selected-concept chips in the demographics panel overflowing and overlapping the "Clear all" button once enough concepts are selected. Root cause: `DemographicRow` rendered the chips through `Title`'s subtitle slot, which forces its content onto one non-wrapping line. Added an opt-in `subTitleWrap` prop to `Title` so this one usage can wrap onto new lines, while every other `Title` consumer (~20 elsewhere) keeps its existing single-line ellipsis behaviour unchanged.

## Jira

https://hdruk.atlassian.net/browse/DP-1098

## PR Type

- [x] `fix`

## PR Title Check

- [x] `fix(DP-1098): Race content chips overlap Clear all`

## Changes Included

- [x] UI changes

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run build` passes

**Note:** this is a pure CSS/flexbox layout fix — RTL/jsdom doesn't compute flex layout, so there's no automated test that can assert the chips wrap instead of overlapping. This has not yet been manually verified in a browser (local dev auth blocked automated visual verification) — please check the Race row with 8+ concepts selected before merging.

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts` — n/a, no routing changes
- [x] API calls follow existing patterns — n/a, no API calls added
- [x] Side-effectful endpoints are not cached unintentionally — n/a
- [x] No sensitive values, secrets, or debug-only code left behind

## Risk and Rollback

- Risk level: low
- Main risk areas:
  - Nested-flexbox `min-width`/`flex` changes are gated behind the new `subTitleWrap` prop (default `false`), so all other `Title` usages are unaffected by construction.
  - Not yet manually verified in-browser — see note above.
- Rollback plan:
  - Revert this PR.

## Notes for Reviewers

Stacked on `feat/DP-1094` (PR #492), which is stacked on `fix/DP-1093` (PR #491), which is stacked on `feat/DP-1092` (PR #489). This PR's diff is limited to `Title.tsx` (new prop) and `DemographicRow.tsx` (one line passing it).

> This PR was implemented with AI assistance (Claude Code).