### PR TITLE
feat(DP-1107): gate Race demographic filter behind feature flag

### DIFF
--- a/src/hooks/useFeatures.ts
+++ b/src/hooks/useFeatures.ts
@@ -52,6 +52,7 @@ const useFeatures = () => {
           flags[FeatureName.QueryBuilderUseValueAsNumber],
         queryBuilderUseLocation: flags[FeatureName.QueryBuilderUseLocation],
         queryBuilderUseDeath: flags[FeatureName.QueryBuilderUseDeath],
+        queryBuilderUseRace: flags[FeatureName.QueryBuilderUseRace],
 
         queryBuilderUseDemographicRule:
           flags[FeatureName.QueryBuilderUseDemographicRule],

--- a/src/modules/DemographicsPanel/DemographicsPanel.test.tsx
+++ b/src/modules/DemographicsPanel/DemographicsPanel.test.tsx
@@ -7,6 +7,8 @@ import {
   EMPTY_DEMOGRAPHICS,
   useQueryBuilderStore,
 } from "@/store/queryBuilderStore";
+import { useFeatureFlagsStore } from "@/store/featureFlagsStore";
+import { FeatureFlag, FeatureName } from "@/types/features";
 import { MAX_AGE_FILTER } from "@/config/rules";
 import DemographicsPanel from "./DemographicsPanel";
 
@@ -138,6 +140,36 @@ describe("DemographicsPanel", () => {
       );
       expect(demographics()?.age).toEqual([30, MAX_AGE_FILTER]);
       expect(demographics()?.sex).toEqual([]);
+    });
+  });
+
+  describe("query-builder-use-race feature flag", () => {
+    beforeEach(() => {
+      store().setQueryBuilderJson(DEFAULT_QUERY);
+      store().setDemographics({ ...EMPTY_DEMOGRAPHICS, sex: [female] });
+    });
+
+    afterEach(() => {
+      useFeatureFlagsStore.setState({ flags: null });
+    });
+
+    it("shows the Race row by default", () => {
+      renderPanel();
+
+      expect(
+        screen.getByRole("button", { name: /edit race/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the Race row when the flag is disabled", () => {
+      useFeatureFlagsStore.setState({
+        flags: { [FeatureName.QueryBuilderUseRace]: false } as FeatureFlag,
+      });
+      renderPanel();
+
+      expect(
+        screen.queryByRole("button", { name: /edit race/i }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/modules/DemographicsPanel/DemographicsPanel.tsx
+++ b/src/modules/DemographicsPanel/DemographicsPanel.tsx
@@ -44,7 +44,7 @@ const DemographicsPanel = ({
       selectedDatasets: qb.selectedDatasets,
     }));
   const user = useUserDataStore((s) => s.user);
-  const { queryBuilderUseLocation } = useFeatures();
+  const { queryBuilderUseLocation, queryBuilderUseRace } = useFeatures();
 
   const age = demographics?.age ?? null;
   const sex = demographics?.sex ?? [];
@@ -61,7 +61,7 @@ const DemographicsPanel = ({
   const summary = [
     formatAgeSummary(age),
     formatConceptCountSummary("Sex", sex),
-    formatConceptCountSummary("Race", race),
+    ...(queryBuilderUseRace ? [formatConceptCountSummary("Race", race)] : []),
     ...(queryBuilderUseLocation ? [formatLocationSummary(location)] : []),
   ].join(" · ");
 
@@ -150,13 +150,15 @@ const DemographicsPanel = ({
             {...propsFor("sex")}
           />
 
-          <DemographicCheckboxSection
-            label="Race"
-            field="race"
-            options={raceConcepts ?? []}
-            selected={race}
-            {...propsFor("race")}
-          />
+          {queryBuilderUseRace && (
+            <DemographicCheckboxSection
+              label="Race"
+              field="race"
+              options={raceConcepts ?? []}
+              selected={race}
+              {...propsFor("race")}
+            />
+          )}
 
           {queryBuilderUseLocation && (
             <DemographicLocationSection {...propsFor("location")} />

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -25,6 +25,7 @@ export enum FeatureName {
   QueryBuilderUseValueAsNumber = "query-builder-use-value-as-number",
   QueryBuilderUseLocation = "query-builder-use-location",
   QueryBuilderUseDeath = "query-builder-use-death",
+  QueryBuilderUseRace = "query-builder-use-race",
 
   QueryBuilderUseDemographicRule = "query-builder-use-demographic-rule",
 
@@ -62,6 +63,7 @@ export const DEFAULT_FLAGS: FeatureFlag = {
   [FeatureName.QueryBuilderUseValueAsNumber]: false,
   [FeatureName.QueryBuilderUseLocation]: false,
   [FeatureName.QueryBuilderUseDeath]: false,
+  [FeatureName.QueryBuilderUseRace]: true,
 
   [FeatureName.QueryBuilderUseDemographicRule]: false,
 


### PR DESCRIPTION
## Summary

Wires up the `query-builder-use-race` feature flag (already live server-side, defaulting to `true` here) to gate the demographics panel's Race section, matching the existing pattern used for the Location section (DP-1037).

## Jira

https://hdruk.atlassian.net/browse/DP-1107

## PR Type

- [x] `feat`

## PR Title Check

- [x] `feat(DP-1107): gate Race demographic filter behind feature flag`

## Changes Included

- [x] UI changes
- [x] State management changes (hooks/store)
- [x] Test updates

## Validation

- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run build` passes

## Coding Conventions Checklist

- [x] New components/modules use existing naming conventions
- [x] Imports follow existing ordering and alias usage (`@/` for internal imports)
- [x] Routes are built with helpers in `src/config/routes.ts` — n/a, no routing changes
- [x] API calls follow existing patterns — n/a, flag value comes through the existing `getFeatureFlags`/`useFeatureFlagsStore` pipeline
- [x] Side-effectful endpoints are not cached unintentionally — n/a
- [x] No sensitive values, secrets, or debug-only code left behind

## Risk and Rollback

- Risk level: low
- Main risk areas:
  - Defaults to `true`, so behaviour is unchanged unless the flag is explicitly turned off server-side.
- Rollback plan:
  - Flip `query-builder-use-race` off server-side, or revert this PR.

## Notes for Reviewers

Stacked on `fix/DP-1098` (PR #493), which is stacked on `feat/DP-1094` (PR #492), which is stacked on `fix/DP-1093` (PR #491), which is stacked on `feat/DP-1092` (PR #489). This PR's diff is limited to `src/types/features.ts`, `src/hooks/useFeatures.ts`, and `DemographicsPanel.tsx`/its test.

> This PR was implemented with AI assistance (Claude Code).